### PR TITLE
fix issues to work with zig 0.11

### DIFF
--- a/util/timer.zig
+++ b/util/timer.zig
@@ -5,12 +5,12 @@ pub const Timer = struct {
     elapsedTime: u64 = 0,
 
     pub fn start(self: *Timer) void {
-        self.startTime = @intCast(std.time.microTimestamp());
+        self.startTime = @intCast(u64, std.time.microTimestamp());
     }
 
     pub fn stop(self: *Timer) void {
         if (self.startTime != 0) {
-            var stamp: u64 = @intCast(std.time.microTimestamp());
+            var stamp: u64 = @intCast(u64, std.time.microTimestamp());
             self.elapsedTime = stamp - self.startTime;
         }
         self.startTime = 0;
@@ -20,12 +20,12 @@ pub const Timer = struct {
         if (self.startTime == 0) {
             return self.elapsedTime;
         } else {
-            var stamp: u64 = @intCast(std.time.microTimestamp());
+            var stamp: u64 = @intCast(u64, std.time.microTimestamp());
             return stamp - self.startTime;
         }
     }
 
     pub fn reset(self: *Timer) void {
-        self.startTime = @intCast(std.time.microTimestamp());
+        self.startTime = @intCast(u64, std.time.microTimestamp());
     }
 };

--- a/zbench.zig
+++ b/zbench.zig
@@ -16,7 +16,7 @@ pub const Benchmark = struct {
     startTime: u64,
 
     pub fn init(name: []const u8, allocator: *std.mem.Allocator) !Benchmark {
-        var startTime: u64 = @intCast(std.time.microTimestamp());
+        var startTime: u64 = @intCast(u64, std.time.microTimestamp());
         if (startTime < 0) {
             std.debug.warn("Failed to get start time. Defaulting to 0.\n", .{});
             startTime = 0;
@@ -247,7 +247,7 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
         const progress = pr * 100;
 
         // Print the progress if it's a new percentage
-        const currentProgress: u8 = @truncate(progress);
+        const currentProgress: u8 = @truncate(u8, progress);
         if (currentProgress != lastProgress) {
             std.debug.print("Progress...({}%)\n", .{currentProgress});
             lastProgress = currentProgress;
@@ -258,7 +258,7 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
     duration = bench.elapsed();
 
     // Adjust N based on the actual duration achieved
-    bench.N = @intCast((bench.N * MIN_DURATION) / duration);
+    bench.N = @intCast(usize, (bench.N * MIN_DURATION) / duration);
 
     // Now run the benchmark with the adjusted N value
     bench.reset();


### PR DESCRIPTION
I was getting lots of compilation errors with zig 0.11 like:
```
❯ zig build run
zig build-exe zbench-fun Debug native: error: the following command failed with 2 compilation errors:
/home/diego/bin/zig-linux-x86_64-0.11.0-dev.3395+1e7dcaa3a/zig build-exe /mnt/e35d88d4-42b9-49ea-bf29-c4c3b018d429/diego/git/diegopacheco/zig-playground/zbench-fun/src/main.zig --cache-dir /mnt/e35d88d4-42b9-49ea-bf29-c4c3b018d429/diego/git/diegopacheco/zig-playground/zbench-fun/zig-cache --global-cache-dir /home/diego/.cache/zig --name zbench-fun --mod zbench::/mnt/e35d88d4-42b9-49ea-bf29-c4c3b018d429/diego/git/diegopacheco/zig-playground/zbench-fun/lib/libs/zbench/zbench.zig --deps zbench --listen=- 
Build Summary: 0/5 steps succeeded; 1 failed (disable with -fno-summary)
run transitive failure
└─ run zbench-fun transitive failure
   ├─ zig build-exe zbench-fun Debug native 2 errors
   └─ install transitive failure
      └─ install zbench-fun transitive failure
         └─ zig build-exe zbench-fun Debug native (reused)
lib/libs/zbench/zbench.zig:250:37: error: expected type 'u8', found 'usize'
        const currentProgress: u8 = @truncate(usize, progress);
```
Same for ```@intCast ```

Here is a simple fix for zig 0.11