### PR TITLE
fix: use duration array length for average calculation

### DIFF
--- a/zbench.zig
+++ b/zbench.zig
@@ -168,17 +168,15 @@ pub const Benchmark = struct {
 
     // Calculate the average duration
     pub fn calculateAverage(self: Benchmark) u64 {
-        // prevent a div by zero: check number of ops
-        const ops = self.totalOperations;
-        if (ops == 0) return 0;
+        // prevent division by zero
+        const len = self.durations.items.len;
+        if (len == 0) return 0;
 
         var sum: u64 = 0;
         for (self.durations.items) |duration| {
             sum += duration;
         }
 
-        const len = self.durations.items.len;
-        if (len == 0) return 0; // avoid division by zero
         const avg = sum / len;
 
         return avg;

--- a/zbench.zig
+++ b/zbench.zig
@@ -172,8 +172,9 @@ pub const Benchmark = struct {
         for (self.durations.items) |duration| {
             sum += duration;
         }
-        const ops = self.totalOperations;
-        const avg = sum / ops;
+        const len = self.durations.items.len;
+        if (len == 0) return 0; // avoid division by zero
+        const avg = sum / len;
         return avg;
     }
 };


### PR DESCRIPTION
closes https://github.com/hendriknielaender/zBench/issues/11

With this modification, the `calculateAverage` method will use the count of recorded durations as the denominator when calculating the average duration per operation, which should address the concern of incorrect or inconsistent results due to multiple increments of self.totalOperations.