### PR TITLE
Change from microsecond to nanosecond timer resolution

### DIFF
--- a/util/print.zig
+++ b/util/print.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+// TODO : do we need a mutex here ?
+
 pub fn prettyPrint(indent: usize, text: []const u8) !void {
     const stdout = std.io.getStdOut().writer();
     var lines = text.splitLines();

--- a/util/timer.zig
+++ b/util/timer.zig
@@ -1,16 +1,20 @@
 const std = @import("std");
 
+/// Timer tracks the time based on Unix timestamps obtained from
+/// std.time.nanoTimestamp, which returns and i128 - which in turn is casted to a u64;
+/// - assuming no machine that runs your code has its clock set pre-Unix epoch, casting to unsigned should be safe
+/// - it will overflow in April of the year 2262, so some time to refactor if needed
 pub const Timer = struct {
     startTime: u64 = 0,
     elapsedTime: u64 = 0,
 
     pub fn start(self: *Timer) void {
-        self.startTime = @intCast(std.time.microTimestamp());
+        self.startTime = @intCast(std.time.nanoTimestamp());
     }
 
     pub fn stop(self: *Timer) void {
         if (self.startTime != 0) {
-            var stamp: u64 = @intCast(std.time.microTimestamp());
+            var stamp: u64 = @intCast(std.time.nanoTimestamp());
             self.elapsedTime = stamp - self.startTime;
         }
         self.startTime = 0;
@@ -20,12 +24,12 @@ pub const Timer = struct {
         if (self.startTime == 0) {
             return self.elapsedTime;
         } else {
-            var stamp: u64 = @intCast(std.time.microTimestamp());
+            var stamp: u64 = @intCast(std.time.nanoTimestamp());
             return stamp - self.startTime;
         }
     }
 
     pub fn reset(self: *Timer) void {
-        self.startTime = @intCast(std.time.microTimestamp());
+        self.startTime = @intCast(std.time.nanoTimestamp());
     }
 };

--- a/util/timer.zig
+++ b/util/timer.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
 /// Timer tracks the time based on Unix timestamps obtained from
-/// std.time.nanoTimestamp, which returns and i128 - which in turn is casted to a u64;
+/// std.time.nanoTimestamp, which returns an i128 - which in turn is casted to a u64;
 /// - assuming no machine that runs your code has its clock set pre-Unix epoch, casting to unsigned should be safe
 /// - it will overflow in April of the year 2262, so some time to refactor if needed
 pub const Timer = struct {

--- a/util/timer.zig
+++ b/util/timer.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 /// Timer tracks the time based on Unix timestamps obtained from
 /// std.time.nanoTimestamp, which returns an i128 - which in turn is casted to a u64;
-/// - assuming no machine that runs your code has its clock set pre-Unix epoch, casting to unsigned should be safe
+/// - assuming no machine that runs this code has its clock set pre-Unix epoch, casting to unsigned should be safe
 /// - it will overflow in April of the year 2262, so some time to refactor if needed
 pub const Timer = struct {
     startTime: u64 = 0,

--- a/zbench.zig
+++ b/zbench.zig
@@ -118,7 +118,7 @@ pub const Benchmark = struct {
 
     // Calculate the p75, p99, and p995 durations
     pub fn calculatePercentiles(self: Benchmark) Percentiles {
-        // quickSort will fail (low == high index), so we need a safety check here
+        // quickSort might fail with an empty input slice, so safety checks first
         const len = self.durations.items.len;
         var lastIndex: usize = 0;
         if (len > 0) {
@@ -277,7 +277,7 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
         .name = bench.name,
         .duration = elapsed,
     });
-    bench.incrementOperations(bench.N); // TODO : is this intentional? should this be a 'set total ops'?
+    bench.incrementOperations(bench.N); // TODO : is this intentional? Should this be a 'set total ops'?
 
     bench.report();
     try bench.prettyPrint();

--- a/zbench.zig
+++ b/zbench.zig
@@ -8,7 +8,7 @@ pub const Benchmark = struct {
     N: usize = 1, // number of iterations
     timer: t.Timer,
     totalOperations: usize = 0,
-    minDuration: u64 = 18446744073709551615,
+    minDuration: u64 = 18446744073709551615, // full 64 bits as a start
     maxDuration: u64 = 0,
     totalDuration: u64 = 0,
     durations: std.ArrayList(u64),
@@ -50,7 +50,7 @@ pub const Benchmark = struct {
 
         self.durations.append(elapsedDuration) catch unreachable;
 
-        self.totalOperations += 1;
+        self.totalOperations += 1; // TODO : verify this is adequate here
     }
 
     // Reset the benchmark
@@ -118,10 +118,8 @@ pub const Benchmark = struct {
 
     // Calculate the p75, p99, and p995 durations
     pub fn calculatePercentiles(self: Benchmark) Percentiles {
-        quickSort(self.durations.items, 0, self.durations.items.len - 1);
-
+        // quickSort will fail (low == high index), so we need a safety check here
         const len = self.durations.items.len;
-
         var lastIndex: usize = 0;
         if (len > 0) {
             lastIndex = len - 1;
@@ -129,6 +127,8 @@ pub const Benchmark = struct {
             std.debug.print("Cannot calculate percentiles: empty durations list\n", .{});
             return Percentiles{ .p75 = 0, .p99 = 0, .p995 = 0 };
         }
+        quickSort(self.durations.items, 0, lastIndex - 1);
+
         const p75Index: usize = len * 75 / 100;
         const p99Index: usize = len * 99 / 100;
         const p995Index: usize = len * 995 / 1000;
@@ -168,12 +168,16 @@ pub const Benchmark = struct {
 
     // Calculate the average duration
     pub fn calculateAverage(self: Benchmark) u64 {
+        // prevent a div by zero: check number of ops
+        const ops = self.totalOperations;
+        if (ops == 0) return 0;
+
         var sum: u64 = 0;
         for (self.durations.items) |duration| {
             sum += duration;
         }
-        const ops = self.totalOperations;
-        const avg = sum / ops;
+        const avg = sum / ops; // TODO : make sure n ops == self.durations.items.len
+
         return avg;
     }
 };
@@ -182,7 +186,7 @@ pub const BenchFunc = fn (*Benchmark) void;
 
 pub const BenchmarkResult = struct {
     name: []const u8,
-    duration: u64, // Duration in milliseconds
+    duration: u64, // for total duration in nanoseconds
 };
 
 pub const BenchmarkResults = struct {
@@ -214,17 +218,16 @@ pub const BenchmarkResults = struct {
 };
 
 pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkResults) !void {
-    const MIN_DURATION = 1_000; // minimum benchmark time in milliseconds (1 second)
-    const MAX_N = 10000;
+    const MIN_DURATION = 1_000_000; // minimum benchmark time in nanoseconds (1 millisecond)
+    const MAX_N = 10000; // maximum number of executions for the final benchmark run
     const MAX_ITERATIONS = 10; // Define a maximum number of iterations
 
-    // initially N=1
-    bench.N = 1;
+    bench.N = 1; // initial value; will be updated...
     var duration: u64 = 0;
     var iterations: usize = 0; // Add an iterations counter
 
     var lastProgress: u8 = 0;
-    // increase N until we've run for a long enough time
+    // increase N until we've run for a sufficiently long enough time
     while (duration < MIN_DURATION and iterations < MAX_ITERATIONS) {
         bench.reset();
 
@@ -262,20 +265,19 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
 
     // Now run the benchmark with the adjusted N value
     bench.reset();
-
     var j: usize = 0;
-
     while (j < bench.N) : (j += 1) {
         bench.start();
         func(bench);
         bench.stop();
     }
+
     const elapsed = bench.elapsed();
     try benchResult.results.append(BenchmarkResult{
         .name = bench.name,
         .duration = elapsed,
     });
-    bench.incrementOperations(bench.N);
+    bench.incrementOperations(bench.N); // TODO : is this intentional? should this be a 'set total ops'?
 
     bench.report();
     try bench.prettyPrint();


### PR DESCRIPTION
- use `std.time.nanoTimestamp` instead of `std.time.microTimestamp`
- adds a safety-check before calling `quickSort`(did we actually record any durations?)
- adds a saftey-check before calling the calculation of avg. duration - note that this might conflict with #12 
- adds some comments / TODOs; you might want to remove them as you deem adequate