### PR TITLE
feat(benchmark): refine operations counting logic

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -24,9 +24,8 @@ fn helloWorld() []const u8 {
     return "Hello, world!";
 }
 
-fn myBenchmark(b: *zbench.Benchmark) void {
+fn myBenchmark(_: *zbench.Benchmark) void {
     _ = helloWorld();
-    b.incrementOperations(1); // increment by 1 after each operation
 }
 
 test "bench test basic" {

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -28,10 +28,9 @@ fn bubbleSort(nums: []i32) void {
     }
 }
 
-fn myBenchmark(b: *zbench.Benchmark) void {
+fn myBenchmark(_: *zbench.Benchmark) void {
     var numbers = [_]i32{ 4, 1, 3, 1, 5, 2 };
     _ = bubbleSort(&numbers);
-    b.incrementOperations(1); // increment by 1 after each operation
 }
 
 test "bench test bubbleSort" {

--- a/zbench.zig
+++ b/zbench.zig
@@ -70,10 +70,6 @@ pub const Benchmark = struct {
         self.totalOperations = ops;
     }
 
-    pub fn incrementOperations(self: *Benchmark, ops: usize) void {
-        self.totalOperations += ops;
-    }
-
     pub fn report(self: *Benchmark) void {
         std.debug.print("Total operations: {}\n", .{self.totalOperations});
     }

--- a/zbench.zig
+++ b/zbench.zig
@@ -49,8 +49,6 @@ pub const Benchmark = struct {
         if (elapsedDuration > self.maxDuration) self.maxDuration = elapsedDuration;
 
         self.durations.append(elapsedDuration) catch unreachable;
-
-        self.totalOperations += 1; // TODO : verify this is adequate here
     }
 
     // Reset the benchmark
@@ -66,6 +64,10 @@ pub const Benchmark = struct {
     // Function to get elapsed time since benchmark start
     pub fn elapsed(self: *Benchmark) u64 {
         return self.timer.elapsed();
+    }
+
+    pub fn setTotalOperations(self: *Benchmark, ops: usize) void {
+        self.totalOperations = ops;
     }
 
     pub fn incrementOperations(self: *Benchmark, ops: usize) void {
@@ -278,8 +280,9 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
         .name = bench.name,
         .duration = elapsed,
     });
-    bench.incrementOperations(bench.N); // TODO : is this intentional? Should this be a 'set total ops'?
 
+    bench.setTotalOperations(bench.N);
     bench.report();
+
     try bench.prettyPrint();
 }


### PR DESCRIPTION
- Removed automatic incrementing of operations count in `stop` method.
- Removed unused `incrementOperations` method.
- Introduced `setOperations` method for explicit count setting.
- Updated example usage and tests to align with new counting logic.

Removed Automatic Incrementing:

Removed the line `self.totalOperations += 1;` from the stop method of the Benchmark struct to prevent automatic incrementing of the operations count.
This change is based on the observation that automatic incrementing may not accurately represent the total operations performed.

Introduced setOperations Method:

Added a `setOperations` method to the Benchmark struct, allowing explicit setting of the operations count as needed.
This method provides a way to explicitly set the operations count to a specific value, providing more control and clarity over the operations count.