### PR TITLE
close memory leak with testing allocator

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -1,17 +1,6 @@
 const std = @import("std");
 const zbench = @import("zbench");
-
-pub const CustomAllocator = struct {
-    allocator: std.mem.Allocator,
-
-    pub fn create() CustomAllocator {
-        return CustomAllocator{ .allocator = std.heap.page_allocator };
-    }
-
-    pub fn as_mut(self: *CustomAllocator) *std.mem.Allocator {
-        return &self.allocator;
-    }
-};
+const test_allocator = std.testing.allocator;
 
 fn helloWorld() []const u8 {
     var result: usize = 0;
@@ -29,13 +18,13 @@ fn myBenchmark(_: *zbench.Benchmark) void {
 }
 
 test "bench test basic" {
-    var customAllocator = CustomAllocator.create();
-    var resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(customAllocator.allocator);
-    var bench = try zbench.Benchmark.init("My Benchmark", customAllocator.as_mut());
+    var resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
+    var bench = try zbench.Benchmark.init("My Benchmark", test_allocator);
 
     var benchmarkResults = zbench.BenchmarkResults{
         .results = resultsAlloc,
     };
+    defer benchmarkResults.results.deinit();
 
     try zbench.run(myBenchmark, &bench, &benchmarkResults);
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -1,18 +1,7 @@
 const std = @import("std");
 const inc = @import("include");
 const zbench = @import("zbench");
-
-pub const CustomAllocator = struct {
-    allocator: std.mem.Allocator,
-
-    pub fn create() CustomAllocator {
-        return CustomAllocator{ .allocator = std.heap.page_allocator };
-    }
-
-    pub fn as_mut(self: *CustomAllocator) *std.mem.Allocator {
-        return &self.allocator;
-    }
-};
+const test_allocator = std.testing.allocator;
 
 fn bubbleSort(nums: []i32) void {
     var i: usize = nums.len - 1;
@@ -34,11 +23,11 @@ fn myBenchmark(_: *zbench.Benchmark) void {
 }
 
 test "bench test bubbleSort" {
-    var customAllocator = CustomAllocator.create();
-    var resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(customAllocator.allocator);
-    var bench = try zbench.Benchmark.init("Bubble Sort Benchmark", customAllocator.as_mut());
+    var resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
+    var bench = try zbench.Benchmark.init("Bubble Sort Benchmark", test_allocator);
     var benchmarkResults = zbench.BenchmarkResults{
         .results = resultsAlloc,
     };
+    defer benchmarkResults.results.deinit();
     try zbench.run(myBenchmark, &bench, &benchmarkResults);
 }

--- a/zbench.zig
+++ b/zbench.zig
@@ -16,7 +16,7 @@ pub const Benchmark = struct {
     startTime: u64,
 
     pub fn init(name: []const u8, allocator: std.mem.Allocator) !Benchmark {
-        var startTime: u64 = @intCast(std.time.microTimestamp());
+        var startTime: u64 = @intCast(std.time.nanoTimestamp());
         if (startTime < 0) {
             std.debug.warn("Failed to get start time. Defaulting to 0.\n", .{});
             startTime = 0;

--- a/zbench.zig
+++ b/zbench.zig
@@ -12,10 +12,10 @@ pub const Benchmark = struct {
     maxDuration: u64 = 0,
     totalDuration: u64 = 0,
     durations: std.ArrayList(u64),
-    allocator: *std.mem.Allocator,
+    allocator: std.mem.Allocator,
     startTime: u64,
 
-    pub fn init(name: []const u8, allocator: *std.mem.Allocator) !Benchmark {
+    pub fn init(name: []const u8, allocator: std.mem.Allocator) !Benchmark {
         var startTime: u64 = @intCast(std.time.microTimestamp());
         if (startTime < 0) {
             std.debug.warn("Failed to get start time. Defaulting to 0.\n", .{});
@@ -24,9 +24,9 @@ pub const Benchmark = struct {
 
         var bench = Benchmark{
             .name = name,
-            .timer = t.Timer{ .startTime = startTime },
-            .durations = std.ArrayList(u64).init(allocator.*),
             .allocator = allocator,
+            .timer = t.Timer{ .startTime = startTime },
+            .durations = std.ArrayList(u64).init(allocator),
             .startTime = startTime,
         };
         bench.timer.start();
@@ -60,7 +60,7 @@ pub const Benchmark = struct {
         self.maxDuration = 0;
         self.totalDuration = 0;
         self.durations.deinit();
-        self.durations = std.ArrayList(u64).init(self.allocator.*);
+        self.durations = std.ArrayList(u64).init(self.allocator);
     }
 
     // Function to get elapsed time since benchmark start
@@ -219,6 +219,7 @@ pub const BenchmarkResults = struct {
 };
 
 pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkResults) !void {
+    defer bench.durations.deinit();
     const MIN_DURATION = 1_000_000; // minimum benchmark time in nanoseconds (1 millisecond)
     const MAX_N = 10000; // maximum number of executions for the final benchmark run
     const MAX_ITERATIONS = 10; // Define a maximum number of iterations
@@ -281,5 +282,6 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
     bench.incrementOperations(bench.N); // TODO : is this intentional? Should this be a 'set total ops'?
 
     bench.report();
+
     try bench.prettyPrint();
 }


### PR DESCRIPTION
- pass allocator by value instead of reference
- deinitialize the allocator after `run`
- update examples, showing how to deinitialize the results memory