### PR TITLE
Migrate to std.time.Timer and tweak benchmark boundaries

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -45,7 +45,7 @@ pub fn build(b: *std.Build) void {
 
     const example_step = b.step("test_examples", "Build examples");
     // Add new examples here
-    for ([_][]const u8{ "basic", "bubble_sort" }) |example_name| {
+    for ([_][]const u8{ "basic", "bubble_sort", "sleep" }) |example_name| {
         const example = b.addTest(.{
             .name = example_name,
             .root_source_file = .{ .path = b.fmt("examples/{s}.zig", .{example_name}) },

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -18,13 +18,11 @@ fn myBenchmark(_: *zbench.Benchmark) void {
 }
 
 test "bench test basic" {
-    var resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
+    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
     var bench = try zbench.Benchmark.init("My Benchmark", test_allocator);
-
     var benchmarkResults = zbench.BenchmarkResults{
         .results = resultsAlloc,
     };
     defer benchmarkResults.results.deinit();
-
     try zbench.run(myBenchmark, &bench, &benchmarkResults);
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -9,9 +9,7 @@ fn bubbleSort(nums: []i32) void {
         var j: usize = 0;
         while (j < i) : (j += 1) {
             if (nums[j] > nums[j + 1]) {
-                var tmp = nums[j];
-                nums[j] = nums[j + 1];
-                nums[j + 1] = tmp;
+                std.mem.swap(i32, &nums[j], &nums[j + 1]);
             }
         }
     }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -23,7 +23,7 @@ fn myBenchmark(_: *zbench.Benchmark) void {
 }
 
 test "bench test bubbleSort" {
-    var resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
+    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
     var bench = try zbench.Benchmark.init("Bubble Sort Benchmark", test_allocator);
     var benchmarkResults = zbench.BenchmarkResults{
         .results = resultsAlloc,

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const zbench = @import("zbench");
+const test_allocator = std.testing.allocator;
+
+fn sooSleepy() void {
+    std.time.sleep(100_000_000);
+}
+
+fn sleepBenchmark(_: *zbench.Benchmark) void {
+    _ = sooSleepy();
+}
+
+test "bench test sleepy" {
+    var bench = try zbench.Benchmark.init("Sleep Benchmark", test_allocator);
+    var resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
+    var benchmarkResults = zbench.BenchmarkResults{
+        .results = resultsAlloc,
+    };
+    defer benchmarkResults.results.deinit();
+
+    try zbench.run(sleepBenchmark, &bench, &benchmarkResults);
+}

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -11,12 +11,11 @@ fn sleepBenchmark(_: *zbench.Benchmark) void {
 }
 
 test "bench test sleepy" {
+    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
     var bench = try zbench.Benchmark.init("Sleep Benchmark", test_allocator);
-    var resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
     var benchmarkResults = zbench.BenchmarkResults{
         .results = resultsAlloc,
     };
     defer benchmarkResults.results.deinit();
-
     try zbench.run(sleepBenchmark, &bench, &benchmarkResults);
 }

--- a/util/timer.zig
+++ b/util/timer.zig
@@ -14,7 +14,7 @@ pub const Timer = struct {
 
     pub fn stop(self: *Timer) void {
         if (self.startTime != 0) {
-            var stamp: u64 = @intCast(std.time.nanoTimestamp());
+            const stamp: u64 = @intCast(std.time.nanoTimestamp());
             self.elapsedTime = stamp - self.startTime;
         }
         self.startTime = 0;
@@ -24,7 +24,7 @@ pub const Timer = struct {
         if (self.startTime == 0) {
             return self.elapsedTime;
         } else {
-            var stamp: u64 = @intCast(std.time.nanoTimestamp());
+            const stamp: u64 = @intCast(std.time.nanoTimestamp());
             return stamp - self.startTime;
         }
     }

--- a/zbench.zig
+++ b/zbench.zig
@@ -208,7 +208,6 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
     bench.N = 1; // initial value; will be updated...
     var duration: u64 = 0;
     var iterations: usize = 0; // Add an iterations counter
-    //var lastProgress: u8 = 0;
 
     // increase N until we've run for a sufficiently long time or exceeded max_iterations
     while (duration < MIN_DURATION and iterations < MAX_ITERATIONS) {
@@ -227,16 +226,6 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
         } else {
             bench.N = MAX_N;
         }
-
-        // // Calculate the progress percentage
-        // const progress = bench.N * 100 / MAX_N;
-        //
-        // // Print the progress if it's a new percentage
-        // const currentProgress: u8 = @truncate(progress);
-        // if (currentProgress != lastProgress) {
-        //     std.debug.print("Preparing...({}%)\n", .{currentProgress});
-        //     lastProgress = currentProgress;
-        // }
 
         iterations += 1; // Increase the iteration counter
         duration += bench.elapsed(); // ...and duration

--- a/zbench.zig
+++ b/zbench.zig
@@ -241,8 +241,9 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
         iterations += 1; // Increase the iteration counter
         duration += bench.elapsed(); // ...and duration
     }
-    // Get the total elapsed time
-    // duration = bench.elapsed();
+
+    // Safety first: make sure the recorded durations aren't all-zero
+    if (duration == 0) duration = 1;
 
     // Adjust N based on the actual duration achieved
     bench.N = @intCast((bench.N * MIN_DURATION) / duration);


### PR DESCRIPTION
This will address #17 and #18. 
- [x] add a simple benchmark example that allows to easily test different boundaries, e.g. maximum number of runs and maximum duration
- [x] revise above mentioned parameters to get a stable setup for testing on different platforms
- [x] implement std.time.Timer based version of zBench (basically clean-up of the draft in branch std-Timer)
- [x] collect some data
- [ ] maybe: find a way to have an integration test based on the sleep example