### PR TITLE
Add lots of new functionality to `run`, update README, tests, examples and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const zbench = @import("zbench");
 
 ### Compatibility Notes
 
-***Supported Version***: As of now, this fork of zBench is tested and supported on Zig version ***0.12.0-dev.1849+bb0f7d55e***.
+***Supported Version***: As of now, this fork of zBench is tested and supported on Zig version ***0.12.0-dev.2076+8fd15c6ca***.
 
 ## Usage
 The main type in this library is the `Benchmark` which contains the state for a single benchmark at any given time. A single instance can (and should) run several

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <img src="logo.png" alt="zBench logo" align="right" width="20%"/>
 
 zBench is a simple benchmarking library for the Zig programming language. It is designed to provide easy-to-use functionality to measure and compare the performance of your code.
+(This is a fork of the original zBench repository. Check the Usage section below to see what's new. *NOTE:* this fork requires a version 0.12.0 compiler).
 
 ## Install Option 1 (build.zig.zon)
 
@@ -89,58 +90,233 @@ Now you can import like this:
 const zbench = @import("zbench");
 ```
 
-## Usage
-Create a new benchmark function in your Zig code. This function should take a single argument of type *zbench.Benchmark. The function would run the code you wish to benchmark.
+### Compatibility Notes
 
+***Supported Version***: As of now, this fork of zBench is tested and supported on Zig version ***0.12.0-dev.1849+bb0f7d55e***.
+
+## Usage
+The main type in this library is the `Benchmark` which contains the state for a single benchmark at any given time. A single instance can (and should) run several
+benchmarks, just not concurrently. You can make use of the timing functionality in `Benchmark` to get timings directly, or you can pass a bench-runner to the `run`
+function. The latter is the simplest, and fits most usecases. Here are some examples:
+
+### Standalone function
+The simplest case is when you wish to benchmark a standalone function
 ```zig
-fn benchmarkMyFunction(b: *zbench.Benchmark) void {
+fn myBenchRunner(b: std.mem.Allocator) void {
     // Code to benchmark here
 }
 ```
-You can then run your benchmarks in a test:
+Note the signature/type of the function; it must take an allocator (even if you don't use it) and return `void` (this may be relaxed in the future).
+You can then run your benchmarks in either a test, or main as an executable. The latter is preferable as tests can generate noise and obscure the benchmark output.
+Next we instantiate a `Benchmark` instance.
 ```zig
-test "bench test" {
-    var allocator = std.heap.page_allocator;
-    var b = try zBench.Benchmark.init("benchmarkMyFunction", &allocator);
-    try zBench.run(benchmarkMyFunction, &b);
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+ 
+    const second: u64 = 1_000_000_000;
+    const bench_iterations: u64 = 128;
+
+    var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
+    defer bench.deinit();
 }
 ```
-
-### Compatibility Notes
-Zig is in active development and the APIs can change frequently, making it challenging to support every dev build. This project currently aims to be compatible with stable, non-development builds to provide a consistent experience for the users.
-
-***Supported Version***: As of now, zBench is tested and supported on Zig version ***0.11.0***.
-
-### Benchmark Functions
-Benchmark functions have the following signature:
-
+The first argument to `init` is an estimate in nanoseconds for how long we want to wait for any given benchmark to finish, the second argument is the maximum
+number of repetitions or runs for each benchmark. Now to perform the benchmark we pass `myBenchRunner` to `bench.run`, and the name of our benchmark.
+The complete example looks like this:
 ```zig
-fn(b: *zbench.Benchmark) void
+const std = @import("std");
+const zbench = @import("zbench");
+
+fn myBenchRunner(_: std.mem.Allocator) void {
+    // Code to benchmark here
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+    const second: u64 = 1_000_000_000;
+    const bench_iterations: u64 = 128;
+
+    var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
+    defer bench.deinit();
+
+    const bench_result = try bench.run(myBenchRunner, "Hello bench");
+    try bench_result.prettyPrint(true);
+}
 ```
-The function body contains the code you wish to benchmark.
-
-You can run multiple benchmark functions in a single program by using zBench.run for each benchmark function.
-
-### Reporting Benchmarks
-
-zBench provides a comprehensive report for each benchmark run. It includes the total operations performed, the average, min, and max durations of operations, and the percentile distribution (p75, p99, p995) of operation durations.
-
+`bench.run` returns a `BenchmarkResult` which can be pretty-printed (more parsing functionality may be added in the future):
 ```yaml
-benchmark           time (avg)    (min ... max)    p75        p99        p995
---------------------------------------------------------------------------------------
-benchmarkMyFunction 1200 ms       (100 ms ... 2000 ms) 1100 ms   1900 ms   1950 ms
+benchmark                 runs     time (avg ± σ)         (min ............. max)      p75        p99        p995
+---------------------------------------------------------------------------------------------------------------------
+Hello bench               128      8.806µs ± 67.0ns       (8.351µs ... 9.185µs)        8.813µs    9.31µs     9.185µs
 ```
 
-This example report indicates that the benchmark "benchmarkMyFunction" was run with an average time of 1200 ms per operation. The minimum and maximum operation times were 100 ms and 2000 ms, respectively. The 75th, 99th, and 99.5th percentiles of operation durations were 1100 ms, 1900 ms, and 1950 ms, respectively.
+### Aggregate runner
+In most cases we want to first set up some state relevant to the benchmark, but we aren't interested in benchmarking the setup code. You can use an aggregate runner (ie. struct)
+to split such initialisation from run code:
+```zig
+const std = @import("std");
+const zbench = @import("zbench");
+
+const StructRunner = struct {
+    const Self = @This();
+
+    nums: [10]u64,
+
+    pub fn init(_: std.mem.Allocator) !Self {
+        return Self { .nums = .{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} };
+    }
+
+    pub fn run(self: *Self) void {
+        var i: usize = 1;
+        while (i < self.nums.len) : (i += 1) {
+            self.nums[i] += self.nums[i-1];
+        }
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+    const second: u64 = 1_000_000_000;
+    const bench_iterations: u64 = 128;
+
+    var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
+    defer bench.deinit();
+
+    const bench_result = try bench.run(StructRunner, "Cumulative sum?");
+    try bench_result.prettyPrint(true);
+}
+```
+An aggregate runner like the above must have the associated methods `run` and `init` (it's free to have other methods as well) with the same signatures as above.
+
+### Aggregate runner with cleanup
+If your runner has to do some form of cleanup such as de-allocating memory, you can additionally declare a `deinit` method. Lets write a runner for benchmarking the
+append-function of the standard library ArrayList. In this case we aren't interested in re-allocating, so we will pre-allocate the space we need:
+```zig
+const std = @import("std");
+const zbench = @import("zbench");
+
+const StructRunner = struct {
+    const Self = @This();
+
+    list: std.ArrayList(usize),
+    alloc: std.mem.Allocator,
+
+    pub fn init(alloc: std.mem.Allocator) !Self {
+        return Self {
+            .list = try std.ArrayList(usize).initCapacity(alloc, 512),
+            .alloc = alloc,
+        };
+    }
+
+    pub fn run(self: *Self) void {
+        for (0..512) |i| self.list.append(i) catch @panic("Append failed!");
+    }
+
+    pub fn deinit(self: Self) void { self.list.deinit(); }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+    const second: u64 = 1_000_000_000;
+    const bench_iterations: u64 = 128;
+
+    var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
+    defer bench.deinit();
+
+    const bench_result = try bench.run(StructRunner, "ArrayList append");
+    try bench_result.prettyPrint(true);
+}
+```
+Note that we can't return errors from `run`, so any errors that occur must be handled immediately and can't be propagated.
+### Aggregate runner with reset
+In order to prevent dependance, `Benchmark` creates a new instance of `StructRunner` between every benchmarking run (this doesn't ensure independance however, you can
+still write/read from global variables in your `run` for example). This involves `init`ing and `deinit`ing every instance between every run, which involves memory allocations.
+In this case (and a lot of cases) that causes easely avoidable slowdowns of our benchmarks. To avoid this we can additionally declare a `reset` method for our runner
+that resets the state, here's how that would look like for the above runner:
+```zig
+const StructRunner = struct {
+    const Self = @This();
+
+    list: std.ArrayList(usize),
+    alloc: std.mem.Allocator,
+
+    pub fn init(alloc: std.mem.Allocator) !Self {
+        return Self {
+            .list = try std.ArrayList(usize).initCapacity(alloc, 512),
+            .alloc = alloc,
+        };
+    }
+
+    pub fn run(self: *Self) void {
+        for (0..512) |i| self.list.append(i) catch @panic("Append failed!");
+    }
+
++   pub fn reset(self: *Self) void {
++       self.list.clearRetainingCapacity();
++   }
+
+    pub fn deinit(self: Self) void { self.list.deinit(); }
+};
+```
+Now `reset` is instead called for every benchmark-run, and `init`/`deinit` are only called once at the start and end of the benchmark respectively.
+
+### Running at printing multiple benchmarks
+You can print multiple results by use the convenience-function `zbench.prettyPrintResults` or just printing them in a for-loop without the header. Here's the `sleep.zig`
+example:
+```zig
+const std = @import("std");
+const zbench = @import("zbench");
+
+fn sleepyFirstRunner(_: std.mem.Allocator) void {
+    std.time.sleep(100_000);
+}
+
+fn sleepySecondRunner(_: std.mem.Allocator) void {
+    std.time.sleep(1_000_000);
+}
+
+fn sleepyThirdRunner(_: std.mem.Allocator) void {
+    std.time.sleep(10_000_000);
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+    const second: u64 = 1_000_000_000;
+    const bench_iterations: u64 = 128;
+
+    var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
+    defer bench.deinit();
+
+    const result1 = try bench.run(sleepyFirstRunner, "Sleepy-first bench");
+    const result2 = try bench.run(sleepySecondRunner, "Sleepy-second bench");
+    const result3 = try bench.run(sleepyThirdRunner, "Sleepy-third bench");
+
+    try zbench.prettyPrintResults(&.{result1, result2, result3}, true);
+}
+```
+```yaml
+benchmark                 runs     time (avg ± σ)         (min ............. max)      p75        p99        p995      
+---------------------------------------------------------------------------------------------------------------------
+Sleepy-first bench        128      161.812µs ± 46.419µs   (157.87µs ... 682.646µs)     157.846µs  170.807µs  682.646µs 
+Sleepy-second bench       128      1.237ms ± 89.535µs     (1.58ms ... 1.925ms)         1.243ms    1.752ms    1.925ms   
+Sleepy-third bench        98       10.259ms ± 161.244µs   (10.78ms ... 11.558ms)       10.248ms   11.558ms   11.558ms
+```
+Check out the `linked_list` example for how to use zig's comptime to neatly run multiple benchmarks.
 
 ### Running zBench Examples
 
-You can run all example tests with the following command:
+You can compile all examples with the following command:
 ```bash
-zig build test_examples
+zig build examples
 ```
+The binaries are placed by default in `./zBench/zig-out/bin/`
 
 ### Troubleshooting
+
 If Zig doesn't detect changes in a dependency, clear the project's `zig-cache` folder and `~/.cache/zig`.
 
 ## Contributing

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const log = std.log.scoped(.zbench_build);
+
 const version = std.SemanticVersion{ .major = 0, .minor = 1, .patch = 0 };
 
 pub fn build(b: *std.Build) void {
@@ -51,8 +53,7 @@ fn setupTesting(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builti
 
 fn addTestsFromDir(b: *std.Build, test_step: *std.Build.Step, dir_path: []const u8, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) void {
     const iterableDir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch {
-        // This error is very undescriptive..
-        std.debug.print("Failed to open directory: {s}\n", .{dir_path});
+        log.warn("failed to open directory: {s}", .{dir_path});
         return;
     };
 
@@ -61,7 +62,7 @@ fn addTestsFromDir(b: *std.Build, test_step: *std.Build.Step, dir_path: []const 
         const optionalEntry = it.next() catch |err| {
             //TODO: break if access denied
             //if (err == std.fs.IterableDir.ChmodError) break;
-            std.debug.print("Directory iteration error: {any}\n", .{err});
+            log.warn("Directory iteration error: {any}", .{err});
             continue;
         };
 

--- a/build.zig
+++ b/build.zig
@@ -50,8 +50,9 @@ fn setupTesting(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builti
 }
 
 fn addTestsFromDir(b: *std.Build, test_step: *std.Build.Step, dir_path: []const u8, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) void {
-    const iterableDir = std.fs.cwd().openIterableDir(dir_path, .{}) catch {
-        std.debug.print("Failed to open directory: {any}\n", .{dir_path});
+    const iterableDir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch {
+        // This error is very undescriptive..
+        std.debug.print("Failed to open directory: {s}\n", .{dir_path});
         return;
     };
 

--- a/build.zig
+++ b/build.zig
@@ -86,7 +86,7 @@ fn addTestsFromDir(b: *std.Build, test_step: *std.Build.Step, dir_path: []const 
 
 fn setupExamples(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) void {
     const example_step = b.step("examples", "Build examples");
-    const example_names = [_][]const u8{ "basic", "bubble_sort", "sleep" };
+    const example_names = [_][]const u8{ "basic", "bubble_sort", "sleep", "linked_list" };
 
     for (example_names) |example_name| {
         const example = b.addExecutable(.{

--- a/build.zig
+++ b/build.zig
@@ -85,11 +85,11 @@ fn addTestsFromDir(b: *std.Build, test_step: *std.Build.Step, dir_path: []const 
 }
 
 fn setupExamples(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) void {
-    const example_step = b.step("test_examples", "Build examples");
+    const example_step = b.step("examples", "Build examples");
     const example_names = [_][]const u8{ "basic", "bubble_sort", "sleep" };
 
     for (example_names) |example_name| {
-        const example = b.addTest(.{
+        const example = b.addExecutable(.{
             .name = example_name,
             .root_source_file = .{ .path = b.fmt("examples/{s}.zig", .{example_name}) },
             .target = target,

--- a/build.zig
+++ b/build.zig
@@ -43,7 +43,7 @@ fn setupTesting(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builti
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
 
-    const test_dirs = [_][]const u8{"util"};
+    const test_dirs = [_][]const u8{"util", "."};
     for (test_dirs) |dir| {
         addTestsFromDir(b, test_step, dir, target, optimize);
     }

--- a/build.zig
+++ b/build.zig
@@ -43,7 +43,7 @@ fn setupTesting(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builti
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
 
-    const test_dirs = [_][]const u8{"util", "."};
+    const test_dirs = [_][]const u8{ "util", "." };
     for (test_dirs) |dir| {
         addTestsFromDir(b, test_step, dir, target, optimize);
     }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,24 +15,24 @@ Declare zbench as a dependency and add it to your `build.zig.zon`. Replace `<COM
 Import zbench in your Zig code and create a benchmark function:
 
 ```zig
+const std = @import("std");
 const zbench = @import("zbench");
 
-fn benchmarkMyFunction(_: *zbench.Benchmark) void {
-    // Benchmark code here
+fn myBenchRunner(_: std.mem.Allocator) void {
+    // Code to benchmark here
 }
-```
 
-Run the benchmark in a test:
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 
-```zig
-test "bench test" {
-    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
-    var bench = try zbench.Benchmark.init("My Benchmark", test_allocator);
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
-    try zbench.run(myBenchmark, &bench, &benchmarkResults);
+    const second: u64 = 1_000_000_000;
+    const bench_iterations: u64 = 128;
+
+    var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
+    defer bench.deinit();
+
+    const bench_result = try bench.run(myBenchRunner, "Hello bench");
+    try bench_result.prettyPrint(true);
 }
 ```
 

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -26,6 +26,6 @@ pub fn main() !void {
     var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
     defer bench.deinit();
 
-    const bench_result = try bench.runBench(myBenchRunner, "Hello benchmark");
+    const bench_result = try bench.runBench(myBenchRunner, "Hello bench");
     try bench_result.prettyPrint(true);
 }

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const zbench = @import("zbench");
-const test_allocator = std.testing.allocator;
 
 fn helloWorld() []const u8 {
     var result: usize = 0;

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -16,6 +16,30 @@ fn myBenchRunner(_: std.mem.Allocator) void {
     _ = helloWorld();
 }
 
+const StructRunner = struct {
+    const Self = @This();
+
+    list: std.ArrayList(usize),
+    alloc: std.mem.Allocator,
+
+    pub fn init(alloc: std.mem.Allocator) !Self {
+        return Self {
+            .list = try std.ArrayList(usize).initCapacity(alloc, 512),
+            .alloc = alloc,
+        };
+    }
+
+    pub fn run(self: *Self) void {
+        for (0..512) |i| self.list.append(i) catch @panic("Append failed!");
+    }
+
+    pub fn reset(self: *Self) void {
+        self.list.clearRetainingCapacity();
+    }
+
+    pub fn deinit(self: Self) void { self.list.deinit(); }
+};
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 
@@ -25,6 +49,6 @@ pub fn main() !void {
     var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
     defer bench.deinit();
 
-    const bench_result = try bench.runBench(myBenchRunner, "Hello bench");
+    const bench_result = try bench.run(StructRunner, "ArrayList append");
     try bench_result.prettyPrint(true);
 }

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -13,16 +13,19 @@ fn helloWorld() []const u8 {
     return "Hello, world!";
 }
 
-fn myBenchmark(_: *zbench.Benchmark) void {
+fn myBenchRunner(_: std.mem.Allocator) void {
     _ = helloWorld();
 }
 
-test "bench test basic" {
-    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
-    var bench = try zbench.Benchmark.init("My Benchmark", test_allocator);
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
-    try zbench.run(myBenchmark, &bench, &benchmarkResults);
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+    const second: u64 = 1_000_000_000;
+    const bench_iterations: u64 = 128;
+
+    var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
+    defer bench.deinit();
+
+    const bench_result = try bench.runBench(myBenchRunner, "Hello benchmark");
+    try bench_result.prettyPrint(true);
 }

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -12,33 +12,9 @@ fn helloWorld() []const u8 {
     return "Hello, world!";
 }
 
-fn myBenchRunner(_: std.mem.Allocator) void {
+fn myBenchRunner() void {
     _ = helloWorld();
 }
-
-const StructRunner = struct {
-    const Self = @This();
-
-    list: std.ArrayList(usize),
-    alloc: std.mem.Allocator,
-
-    pub fn init(alloc: std.mem.Allocator) !Self {
-        return Self {
-            .list = try std.ArrayList(usize).initCapacity(alloc, 512),
-            .alloc = alloc,
-        };
-    }
-
-    pub fn run(self: *Self) void {
-        for (0..512) |i| self.list.append(i) catch @panic("Append failed!");
-    }
-
-    pub fn reset(self: *Self) void {
-        self.list.clearRetainingCapacity();
-    }
-
-    pub fn deinit(self: Self) void { self.list.deinit(); }
-};
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -49,6 +25,6 @@ pub fn main() !void {
     var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
     defer bench.deinit();
 
-    const bench_result = try bench.run(StructRunner, "ArrayList append");
+    const bench_result = try bench.run(myBenchRunner, "ArrayList append");
     try bench_result.prettyPrint(true);
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -34,6 +34,6 @@ pub fn main() !void {
     var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
     defer bench.deinit();
 
-    const bench_result = try bench.runBench(BubbleSortRunner, "Bubble-sort benchmark");
+    const bench_result = try bench.runBench(BubbleSortRunner, "Bubble-sort bench");
     try bench_result.prettyPrint(true);
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -33,6 +33,6 @@ pub fn main() !void {
     var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
     defer bench.deinit();
 
-    const bench_result = try bench.runBench(BubbleSortRunner, "Bubble-sort bench");
+    const bench_result = try bench.run(BubbleSortRunner, "Bubble-sort bench");
     try bench_result.prettyPrint(true);
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -8,7 +8,7 @@ const BubbleSortRunner = struct {
     nums: [10]i32,
 
     pub fn init(_: std.mem.Allocator) !Self {
-        return Self{ .nums = [_]i32{ 4, 1, 3, 1, 5, 2, 6, 0, 7, 8} };
+        return Self{ .nums = [_]i32{ 4, 1, 3, 1, 5, 2, 6, 0, 7, 8 } };
     }
 
     pub fn run(self: *Self) void {

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const inc = @import("include");
 const zbench = @import("zbench");
-const test_allocator = std.testing.allocator;
 
 const BubbleSortRunner = struct {
     const Self = @This();

--- a/examples/linked_list.zig
+++ b/examples/linked_list.zig
@@ -75,7 +75,7 @@ pub fn main() !void {
 
     zbench.prettyPrintHeader();
     inline for (runners) |Runner|
-        try (try bench.runBench(Runner, Runner.name)).prettyPrint(false);
+        try (try bench.run(Runner, Runner.name)).prettyPrint(false);
 }
 
 // Below lies a simple (and unfinished) doubly linked-list implementation

--- a/examples/linked_list.zig
+++ b/examples/linked_list.zig
@@ -8,61 +8,55 @@ const runners = .{
     struct {
         const Self = @This();
         const name = "linked-list append-128";
-
         ll: LinkedList(i128),
-
         pub fn init(alloc: std.mem.Allocator) !Self {
-            return Self { .ll = LinkedList(i128).init(alloc) };
+            return Self{ .ll = LinkedList(i128).init(alloc) };
         }
-
         pub fn run(self: *Self) void {
             for (0..128) |i| self.ll.append(i) catch @panic("Alloc error!");
         }
-
-        pub fn deinit(self: *Self) void { self.ll.deinit(); }
+        pub fn deinit(self: *Self) void {
+            self.ll.deinit();
+        }
     },
 
     // Runner for popping from list with 128 elements
     struct {
         const Self = @This();
         const name = "linked-list pop-128";
-
         ll: LinkedList(i128),
-
         pub fn init(alloc: std.mem.Allocator) !Self {
             var ll = LinkedList(i128).init(alloc);
             for (0..128) |i| ll.append(i) catch @panic("Alloc error!");
-            return Self { .ll = ll };
+            return Self{ .ll = ll };
         }
-
         pub fn run(self: *Self) void {
             for (0..128) |_| _ = self.ll.pop();
         }
-
-        pub fn deinit(self: *Self) void { self.ll.deinit(); }
+        pub fn deinit(self: *Self) void {
+            self.ll.deinit();
+        }
     },
 
     // Runner for iterating over a list with 128 elements and addint 1 to each element
     struct {
         const Self = @This();
         const name = "linked-list iter-128";
-
         ll: LinkedList(i128),
-
         pub fn init(alloc: std.mem.Allocator) !Self {
             var ll = LinkedList(i128).init(alloc);
             for (0..128) |i| ll.append(i) catch @panic("Alloc error!");
-            return Self { .ll = ll};
+            return Self{ .ll = ll };
         }
-
         pub fn run(self: *Self) void {
             var it = self.ll.iterStart();
             while (it.next()) |elem| {
                 elem.* += 1;
             }
         }
-
-        pub fn deinit(self: *Self) void { self.ll.deinit(); }
+        pub fn deinit(self: *Self) void {
+            self.ll.deinit();
+        }
     },
 };
 

--- a/examples/linked_list.zig
+++ b/examples/linked_list.zig
@@ -1,0 +1,328 @@
+const std = @import("std");
+const zbench = @import("zbench");
+const Benchmark = zbench.Benchmark;
+
+// We can collect runners in a tuple like this to easily iterate over them
+const runners = .{
+    // Runner for appending 128 elements
+    struct {
+        const Self = @This();
+        const name = "linked-list append-128";
+
+        ll: LinkedList(i128),
+
+        pub fn init(alloc: std.mem.Allocator) !Self {
+            return Self { .ll = LinkedList(i128).init(alloc) };
+        }
+
+        pub fn run(self: *Self) void {
+            for (0..128) |i| self.ll.append(i) catch @panic("Alloc error!");
+        }
+
+        pub fn deinit(self: *Self) void { self.ll.deinit(); }
+    },
+
+    // Runner for popping from list with 128 elements
+    struct {
+        const Self = @This();
+        const name = "linked-list pop-128";
+
+        ll: LinkedList(i128),
+
+        pub fn init(alloc: std.mem.Allocator) !Self {
+            var ll = LinkedList(i128).init(alloc);
+            for (0..128) |i| ll.append(i) catch @panic("Alloc error!");
+            return Self { .ll = ll };
+        }
+
+        pub fn run(self: *Self) void {
+            for (0..128) |_| _ = self.ll.pop();
+        }
+
+        pub fn deinit(self: *Self) void { self.ll.deinit(); }
+    },
+
+    // Runner for iterating over a list with 128 elements and addint 1 to each element
+    struct {
+        const Self = @This();
+        const name = "linked-list iter-128";
+
+        ll: LinkedList(i128),
+
+        pub fn init(alloc: std.mem.Allocator) !Self {
+            var ll = LinkedList(i128).init(alloc);
+            for (0..128) |i| ll.append(i) catch @panic("Alloc error!");
+            return Self { .ll = ll};
+        }
+
+        pub fn run(self: *Self) void {
+            var it = self.ll.iterStart();
+            while (it.next()) |elem| {
+                elem.* += 1;
+            }
+        }
+
+        pub fn deinit(self: *Self) void { self.ll.deinit(); }
+    },
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+    const runs: usize = 128;
+    var bench = try Benchmark.init(1_000_000_000, runs, gpa.allocator());
+    defer bench.deinit();
+
+    zbench.prettyPrintHeader();
+    inline for (runners) |Runner|
+        try (try bench.runBench(Runner, Runner.name)).prettyPrint(false);
+}
+
+// Below lies a simple (and unfinished) doubly linked-list implementation
+// Feel free to complete it and add more benchmarks!
+
+fn Node(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        next: ?*Node(T),
+        prev: ?*Node(T),
+        val: T,
+    };
+}
+
+fn Iterator(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        node: ?*Node(T),
+
+        // NOTE: Should this return a pointer to the element? Unsure..
+        pub fn next(self: *Self) ?*T {
+            if (self.node) |node| {
+                const ret = &node.val;
+                self.node = node.next;
+
+                return ret;
+            } else {
+                return null;
+            }
+        }
+
+        pub fn prev(self: *Self) ?*T {
+            if (self.node) |node| {
+                const ret = &node.val;
+                self.node = node.prev;
+
+                return ret;
+            } else {
+                return null;
+            }
+        }
+    };
+}
+
+/// Doubly linked list (not optimised)
+pub fn LinkedList(comptime T: type) type {
+    return struct {
+        const Self = @This();
+        const Allocator = @import("std").mem.Allocator;
+
+        alloc: Allocator,
+        head: ?*Node(T),
+        tail: ?*Node(T),
+        // curr: ?*Node(T),
+
+        len: usize,
+
+        fn getNodeAt(self: *const Self, idx: usize) ?*const Node(T) {
+            if (idx >= self.len or idx < 0) {
+                return null;
+            }
+
+            if (idx < self.len / 2) {
+                var i: usize = 0;
+                var node = self.head.?;
+                while (true) : (i += 1) {
+                    if (i == idx) break;
+                    node = node.next.?;
+                }
+                return node;
+            } else {
+                var i: usize = self.len - 1;
+                var node = self.tail.?;
+                while (true) : (i -= 1) {
+                    if (i == idx) break;
+                    node = node.prev.?;
+                }
+                return node;
+            }
+        }
+
+        pub fn init(allocator: std.mem.Allocator) Self {
+            return Self{
+                .alloc = allocator,
+                .head = null,
+                .tail = null,
+                //.curr = null,
+                .len = 0,
+            };
+        }
+
+        pub fn append(self: *Self, val: T) !void {
+            if (self.len == 0) {
+                self.head = try self.alloc.create(Node(T));
+                self.head.?.* = Node(T){ .val = val, .next = null, .prev = null };
+
+                self.tail = self.head.?;
+            } else {
+                const new_node = try self.alloc.create(Node(T));
+                new_node.* = Node(T){ .val = val, .next = null, .prev = self.tail };
+                self.tail.?.*.next = new_node;
+                self.tail = new_node;
+            }
+
+            self.len += 1;
+        }
+
+        pub fn insert(self: *Self, val: T, idx: usize) !void {
+            // TODO: Implement and benchmark me :(
+            _ = val;
+            _ = idx;
+            _ = self;
+
+            @panic("Not implemented");
+        }
+
+        pub fn appendSlice(self: *Self, items: []const T) !void {
+            for (items) |item| {
+                try self.append(item);
+            }
+        }
+
+        pub fn pop(self: *Self) ?T {
+            if (self.len == 0) {
+                return null;
+            }
+
+            const ret = self.tail.?.*.val;
+            const prev = self.tail.?.*.prev;
+            self.alloc.destroy(self.tail.?);
+
+            self.tail = prev;
+
+            if (self.tail) |node| {
+                node.next = null;
+            } else {
+                // We only hit this branch if the popped tail was the last node
+                // so make sure to null out head as-well since the list is empty
+                self.head = null;
+            }
+
+            self.len -= 1;
+            return ret;
+        }
+
+        pub fn deinit(self: *Self) void {
+            var node = if (self.head) |node| node else {
+                return {};
+            };
+
+            while (node.next) |next| {
+                self.alloc.destroy(node);
+                node = next;
+            }
+
+            self.alloc.destroy(node);
+        }
+
+        pub fn iterStart(self: *Self) Iterator(T) {
+            return Iterator(T){ .node = self.head };
+        }
+
+        pub fn iterEnd(self: *Self) Iterator(T) {
+            return Iterator(T){ .node = self.tail };
+        }
+    };
+}
+
+// --- Unit tests --- //
+const assert = @import("std").testing.expect;
+const test_alloc = @import("std").testing.allocator;
+const print = @import("std").debug.print;
+
+test "list append" {
+    var list = LinkedList(u8).init(test_alloc);
+    try assert(list.len == 0);
+
+    try list.append('a');
+    try assert(list.len == 1 and list.head.?.*.val == 'a' and list.tail.?.*.val == 'a');
+
+    try list.append('b');
+    try assert(list.len == 2 and list.head.?.*.val == 'a' and list.tail.?.*.val == 'b');
+
+    try list.append('c');
+    try assert(list.len == 3 and list.head.?.*.val == 'a' and list.tail.?.*.val == 'c');
+
+    list.deinit();
+}
+
+test "list iterator" {
+    var list = LinkedList(u8).init(test_alloc);
+    defer list.deinit();
+
+    const alph = [_]u8{ 'a', 'b', 'c', 'd', 'e' };
+    try list.appendSlice(&alph);
+
+    var i: usize = 0;
+    var iterf = list.iterStart();
+    while (iterf.next()) |val| {
+        try assert(val.* == alph[i]);
+        i += 1;
+    }
+
+    try assert(i == alph.len);
+
+    var iterb = list.iterEnd();
+    while (iterb.prev()) |val| {
+        i -= 1;
+        try assert(val.* == alph[i]);
+    }
+
+    try assert(i == 0);
+}
+
+test "list get at index" {
+    var list = LinkedList(u8).init(test_alloc);
+    defer list.deinit();
+
+    const alph = [_]u8{ 'a', 'b', 'c', 'd', 'e' };
+    try list.appendSlice(&alph);
+
+    for (0..alph.len) |i| {
+        const val = if (list.getNodeAt(i)) |node| node.*.val else {
+            @panic("");
+        };
+        //print("expected {d} | computed {d}\n", .{ alph[i], val });
+        try assert(alph[i] == val);
+    }
+}
+
+test "list pop" {
+    var list = LinkedList(u8).init(test_alloc);
+    defer list.deinit();
+
+    const alph = [_]u8{ 'a', 'b', 'c', 'd', 'e' };
+    try list.appendSlice(&alph);
+
+    var i: usize = alph.len - 1;
+    while (true) : (i -= 1) {
+        const val = list.pop().?;
+        //print("expected {d} | computed {d}\n", .{ alph[i], val });
+        try assert(alph[i] == val);
+        try assert(list.len == i);
+        if (i == 0) break;
+    }
+
+    try assert(list.len == 0);
+}

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -22,9 +22,9 @@ pub fn main() !void {
     var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
     defer bench.deinit();
 
-    const result1 = try bench.runBench(sleepyFirstRunner, "Sleepy-first bench");
-    const result2 = try bench.runBench(sleepySecondRunner, "Sleepy-second bench");
-    const result3 = try bench.runBench(sleepyThirdRunner, "Sleepy-third bench");
+    const result1 = try bench.run(sleepyFirstRunner, "Sleepy-first bench");
+    const result2 = try bench.run(sleepySecondRunner, "Sleepy-second bench");
+    const result3 = try bench.run(sleepyThirdRunner, "Sleepy-third bench");
 
     try zbench.prettyPrintResults(&.{result1, result2, result3}, true);
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -26,5 +26,5 @@ pub fn main() !void {
     const result2 = try bench.run(sleepySecondRunner, "Sleepy-second bench");
     const result3 = try bench.run(sleepyThirdRunner, "Sleepy-third bench");
 
-    try zbench.prettyPrintResults(&.{result1, result2, result3}, true);
+    try zbench.prettyPrintResults(&.{ result1, result2, result3 }, true);
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -1,21 +1,30 @@
 const std = @import("std");
 const zbench = @import("zbench");
-const test_allocator = std.testing.allocator;
 
-fn sooSleepy() void {
-    std.time.sleep(100_000_000);
+fn sleepyFirstRunner(_: std.mem.Allocator) void {
+    std.time.sleep(100_000);
 }
 
-fn sleepBenchmark(_: *zbench.Benchmark) void {
-    _ = sooSleepy();
+fn sleepySecondRunner(_: std.mem.Allocator) void {
+    std.time.sleep(1_000_000);
 }
 
-test "bench test sleepy" {
-    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
-    var bench = try zbench.Benchmark.init("Sleep Benchmark", test_allocator);
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
-    try zbench.run(sleepBenchmark, &bench, &benchmarkResults);
+fn sleepyThirdRunner(_: std.mem.Allocator) void {
+    std.time.sleep(10_000_000);
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+    const second: u64 = 1_000_000_000;
+    const bench_iterations: u64 = 128;
+
+    var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
+    defer bench.deinit();
+
+    const result1 = try bench.runBench(sleepyFirstRunner, "Sleepy-first benchmark");
+    const result2 = try bench.runBench(sleepySecondRunner, "Sleepy-second benchmark");
+    const result3 = try bench.runBench(sleepyThirdRunner, "Sleepy-third benchmark");
+
+    try zbench.prettyPrintResults(&.{result1, result2, result3}, true);
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -22,9 +22,9 @@ pub fn main() !void {
     var bench = try zbench.Benchmark.init(second, bench_iterations, gpa.allocator());
     defer bench.deinit();
 
-    const result1 = try bench.runBench(sleepyFirstRunner, "Sleepy-first benchmark");
-    const result2 = try bench.runBench(sleepySecondRunner, "Sleepy-second benchmark");
-    const result3 = try bench.runBench(sleepyThirdRunner, "Sleepy-third benchmark");
+    const result1 = try bench.runBench(sleepyFirstRunner, "Sleepy-first bench");
+    const result2 = try bench.runBench(sleepySecondRunner, "Sleepy-second bench");
+    const result3 = try bench.runBench(sleepyThirdRunner, "Sleepy-third bench");
 
     try zbench.prettyPrintResults(&.{result1, result2, result3}, true);
 }

--- a/tests.zig
+++ b/tests.zig
@@ -5,18 +5,18 @@ const print = std.debug.print;
 const Benchmark = @import("./zbench.zig").Benchmark;
 
 test "benchmark runBench with standalone function" {
-    var bench = try Benchmark.init("whatever", test_alloc);
+    var bench = try Benchmark.init(1000, 128, test_alloc);
     defer bench.deinit();
 
     const Nested = struct {
         pub fn run(_: std.mem.Allocator) void {}
     };
 
-    _ = try bench.runBench(Nested.run, 1000, 128);
+    _ = try bench.runBench(Nested.run, "test_bench");
 }
 
 test "benchmark runBench with enum runner with init and run" {
-    var bench = try Benchmark.init("whatever", test_alloc);
+    var bench = try Benchmark.init(1000, 128, test_alloc);
     defer bench.deinit();
 
     const Runner = enum {
@@ -28,11 +28,11 @@ test "benchmark runBench with enum runner with init and run" {
         pub fn run(_: *Self) void {}
     };
 
-    _ = try bench.runBench(Runner, 1000, 128);
+    _ = try bench.runBench(Runner, "test_bench");
 }
 
 test "benchmark runBench with struct runner with init, run and deinit" {
-    var bench = try Benchmark.init("whatever", test_alloc);
+    var bench = try Benchmark.init(1000, 128, test_alloc);
     defer bench.deinit();
 
     const Runner = struct {
@@ -55,11 +55,11 @@ test "benchmark runBench with struct runner with init, run and deinit" {
         pub fn deinit(self: Self) void { self.alloc.free(self.items); }
     };
 
-    _ = try bench.runBench(Runner, 1000, 128);
+    _ = try bench.runBench(Runner, "test_bench");
 }
 
 test "benchmark runBench with complete bench-runner struct" {
-    var bench = try Benchmark.init("whatever", test_alloc);
+    var bench = try Benchmark.init(1000, 128, test_alloc);
     defer bench.deinit();
 
     const Runner = struct {
@@ -84,5 +84,5 @@ test "benchmark runBench with complete bench-runner struct" {
         }
     };
 
-    _ = try bench.runBench(Runner, 1000, 128);
+    _ = try bench.runBench(Runner, "test_bench");
 }

--- a/tests.zig
+++ b/tests.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const test_alloc = std.testing.allocator;
+const print = std.debug.print;
+
+const Benchmark = @import("./zbench.zig").Benchmark;
+
+test "benchmark run bench" {
+    var bench = try Benchmark.init("whatever", test_alloc);
+
+    const Runner = struct {
+        const Self = @This();
+
+        pub fn init(_: std.mem.Allocator) !Self { return Self{}; }
+        pub fn run(_: Self) !void {}
+    };
+
+    _ = try bench.runBench(Runner, 1000, 128);
+}

--- a/tests.zig
+++ b/tests.zig
@@ -20,11 +20,11 @@ test "benchmark run with standalone function" {
     try expectEq(runs, res.total_operations);
 
     // We also expect the Benchmark instance to be reset
-    try expectEq(@as(usize,0), bench.total_operations);
+    try expectEq(@as(usize, 0), bench.total_operations);
     try expectEq(@as(usize, std.math.maxInt(u64)), bench.min_duration);
-    try expectEq(@as(usize,0), bench.max_duration);
-    try expectEq(@as(usize,0), bench.total_duration);
-    try expectEq(@as(usize,0), bench.durations.items.len);
+    try expectEq(@as(usize, 0), bench.max_duration);
+    try expectEq(@as(usize, 0), bench.total_duration);
+    try expectEq(@as(usize, 0), bench.durations.items.len);
 
     // These fields should stay the same however
     try expectEq(@as(usize, std.math.maxInt(u64)), bench.max_duration_limit);
@@ -33,7 +33,6 @@ test "benchmark run with standalone function" {
     // NOTE: Not sure why we need all these casts, but the compiler complains otherwise..
 }
 
-// NOTE: The above four tests are purely testing the metaprogramming and not any actual values
 test "benchmark run with enum runner with init and run" {
     const runs: usize = 128;
     var bench = try Benchmark.init(std.math.maxInt(u64), runs, test_alloc);
@@ -44,7 +43,9 @@ test "benchmark run with enum runner with init and run" {
 
         Variant,
 
-        pub fn init(_: std.mem.Allocator) !Self { return Self.Variant; }
+        pub fn init(_: std.mem.Allocator) !Self {
+            return Self.Variant;
+        }
         pub fn run(_: *Self) void {}
     };
 
@@ -67,7 +68,7 @@ test "benchmark run with struct runner with init, run and deinit" {
 
         pub fn init(a: std.mem.Allocator) !Self {
             Self.init_count += 1;
-            return Self { .items = try a.alloc(u8, 5), .alloc = a };
+            return Self{ .items = try a.alloc(u8, 5), .alloc = a };
         }
         pub fn run(self: Self) void {
             if (self.items[1] >= self.items[2]) {
@@ -77,7 +78,9 @@ test "benchmark run with struct runner with init, run and deinit" {
             }
         }
 
-        pub fn deinit(self: Self) void { self.alloc.free(self.items); }
+        pub fn deinit(self: Self) void {
+            self.alloc.free(self.items);
+        }
     };
 
     const res = try bench.run(Runner, "test_bench");
@@ -106,7 +109,7 @@ test "benchmark run with complete bench-runner struct" {
 
         pub fn init(a: std.mem.Allocator) !Self {
             Self.init_count += 1;
-            return Self { .items = try a.alloc(u64, 64), .alloc = a };
+            return Self{ .items = try a.alloc(u64, 64), .alloc = a };
         }
         pub fn run(self: Self) void {
             for (self.items, 0..) |*item, i| {
@@ -137,14 +140,13 @@ test "benchmark run with complete bench-runner struct" {
 }
 
 test "benchmark quickSort" {
-    comptime var nums = [_]u64{2, 3, 4, 6, 1, 8, 0, 5};
-    comptime Benchmark.quickSort(&nums, 0, nums.len-1);
+    comptime var nums = [_]u64{ 2, 3, 4, 6, 1, 8, 0, 5 };
+    comptime Benchmark.quickSort(&nums, 0, nums.len - 1);
 
-    try expectEq([_]u64{0, 1, 2, 3, 4, 5, 6, 8}, nums);
+    try expectEq([_]u64{ 0, 1, 2, 3, 4, 5, 6, 8 }, nums);
 }
 
 // TODO: Add a test for Benchmark.calculatePercentiles
-
 
 test "benchmark calculateAverage and calulateStd" {
     var bench = try Benchmark.init(std.math.maxInt(u64), 8, test_alloc);

--- a/tests.zig
+++ b/tests.zig
@@ -4,14 +4,84 @@ const print = std.debug.print;
 
 const Benchmark = @import("./zbench.zig").Benchmark;
 
-test "benchmark run bench" {
+test "benchmark runBench with standalone function" {
     var bench = try Benchmark.init("whatever", test_alloc);
+    defer bench.deinit();
+
+    const Nested = struct {
+        pub fn run(_: std.mem.Allocator) void {}
+    };
+
+    _ = try bench.runBench(Nested.run, 1000, 128);
+}
+
+test "benchmark runBench with enum runner with init and run" {
+    var bench = try Benchmark.init("whatever", test_alloc);
+    defer bench.deinit();
+
+    const Runner = enum {
+        const Self = @This();
+
+        Variant,
+
+        pub fn init(_: std.mem.Allocator) !Self { return Self.Variant; }
+        pub fn run(_: *Self) void {}
+    };
+
+    _ = try bench.runBench(Runner, 1000, 128);
+}
+
+test "benchmark runBench with struct runner with init, run and deinit" {
+    var bench = try Benchmark.init("whatever", test_alloc);
+    defer bench.deinit();
 
     const Runner = struct {
         const Self = @This();
 
-        pub fn init(_: std.mem.Allocator) !Self { return Self{}; }
-        pub fn run(_: Self) !void {}
+        items: []u8,
+        alloc: std.mem.Allocator,
+
+        pub fn init(a: std.mem.Allocator) !Self {
+            return Self { .items = try a.alloc(u8, 5), .alloc = a };
+        }
+        pub fn run(self: Self) void {
+            if (self.items[1] >= self.items[2]) {
+                self.items[2] = self.items[3];
+            } else {
+                self.items[1] = self.items[4];
+            }
+        }
+
+        pub fn deinit(self: Self) void { self.alloc.free(self.items); }
+    };
+
+    _ = try bench.runBench(Runner, 1000, 128);
+}
+
+test "benchmark runBench with complete bench-runner struct" {
+    var bench = try Benchmark.init("whatever", test_alloc);
+    defer bench.deinit();
+
+    const Runner = struct {
+        const Self = @This();
+
+        items: []u64,
+        alloc: std.mem.Allocator,
+
+        pub fn init(a: std.mem.Allocator) !Self {
+            return Self { .items = try a.alloc(u64, 64), .alloc = a };
+        }
+        pub fn run(self: Self) void {
+            for (self.items, 0..) |*item, i| {
+                if (item.* <= i) item.* = i else item.* = 0;
+            }
+        }
+        pub fn deinit(self: Self) void {
+            self.alloc.free(self.items);
+        }
+        pub fn reset(self: Self) void {
+            @memset(self.items, 0);
+        }
     };
 
     _ = try bench.runBench(Runner, 1000, 128);

--- a/tests.zig
+++ b/tests.zig
@@ -5,7 +5,7 @@ const expectEq = std.testing.expectEqual;
 
 const Benchmark = @import("./zbench.zig").Benchmark;
 
-test "benchmark runBench with standalone function" {
+test "benchmark run with standalone function" {
     const runs: usize = 128;
     var bench = try Benchmark.init(std.math.maxInt(u64), runs, test_alloc);
     defer bench.deinit();
@@ -14,7 +14,7 @@ test "benchmark runBench with standalone function" {
         pub fn run(_: std.mem.Allocator) void {}
     };
 
-    const res = try bench.runBench(Nested.run, "test_bench");
+    const res = try bench.run(Nested.run, "test_bench");
 
     // We set no time-limit, so it should perform all the runs requested
     try expectEq(runs, res.total_operations);
@@ -34,7 +34,7 @@ test "benchmark runBench with standalone function" {
 }
 
 // NOTE: The above four tests are purely testing the metaprogramming and not any actual values
-test "benchmark runBench with enum runner with init and run" {
+test "benchmark run with enum runner with init and run" {
     const runs: usize = 128;
     var bench = try Benchmark.init(std.math.maxInt(u64), runs, test_alloc);
     defer bench.deinit();
@@ -48,12 +48,12 @@ test "benchmark runBench with enum runner with init and run" {
         pub fn run(_: *Self) void {}
     };
 
-    const res = try bench.runBench(Runner, "test_bench");
+    const res = try bench.run(Runner, "test_bench");
 
     try expectEq(runs, res.total_operations);
 }
 
-test "benchmark runBench with struct runner with init, run and deinit" {
+test "benchmark run with struct runner with init, run and deinit" {
     const runs: usize = 128;
     var bench = try Benchmark.init(std.math.maxInt(u64), runs, test_alloc);
     defer bench.deinit();
@@ -80,17 +80,17 @@ test "benchmark runBench with struct runner with init, run and deinit" {
         pub fn deinit(self: Self) void { self.alloc.free(self.items); }
     };
 
-    const res = try bench.runBench(Runner, "test_bench");
+    const res = try bench.run(Runner, "test_bench");
 
     try expectEq(runs, res.total_operations);
 
     // The runner should have been initialised as many times as there were runs, plus 1
     // NOTE: Although ideally it should be initialised exactly as many times as runs, it's
-    // just the metaprogramming in `runBench` gets more akward if we try to make that happen
+    // just the metaprogramming in `run` gets more akward if we try to make that happen
     try expectEq(runs + 1, Runner.init_count);
 }
 
-test "benchmark runBench with complete bench-runner struct" {
+test "benchmark run with complete bench-runner struct" {
     const runs: usize = 128;
     var bench = try Benchmark.init(std.math.maxInt(u64), runs, test_alloc);
     defer bench.deinit();
@@ -123,7 +123,7 @@ test "benchmark runBench with complete bench-runner struct" {
         }
     };
 
-    const res = try bench.runBench(Runner, "test_bench");
+    const res = try bench.run(Runner, "test_bench");
     try expectEq(runs, res.total_operations);
 
     // Since a reset function was provided the runner should only be inited once

--- a/zbench.zig
+++ b/zbench.zig
@@ -31,12 +31,12 @@ pub const Benchmark = struct {
     /// Initializes a new Benchmark instance.
     ///
     /// max_duration_limit: Max amount of time (in nanoseconds) we are willing
-    /// to wait for any given invocation of `runBench`. Set this to a high number
+    /// to wait for any given invocation of `run`. Set this to a high number
     /// if you don't want time restrictions (ie. std.math.maxInt(u64)). NOTE: This
     /// is only an estimate and bench-runs may exceed the limit slightly.
     ///
     /// max_opererations: Maximum amount of benchmark-runs performed for any
-    /// given invocation of `runBench`. This may be lower if the bench-time
+    /// given invocation of `run`. This may be lower if the bench-time
     /// exceeds max_duration_estimate.
     ///
     /// allocator: Memory allocator to be used.
@@ -57,7 +57,7 @@ pub const Benchmark = struct {
 
     /// Runner: Must be one of either -
     ///     Standalone function with following signature/function type -
-    ///         fn (std.mem.Allocator) void         : Required
+    ///         fn (std.mem.Allocator) void             : Required
     ///
     ///     Aggregate (Struct/Union/Enum) with followin associated methods -
     ///         pub fn init(std.mem.Allocator) !Self    : Required
@@ -74,7 +74,7 @@ pub const Benchmark = struct {
     ///
     ///     If the above restrictions aren't matched exactly you may get strange
     ///     compilation errors that can be hard to debug!
-    pub fn runBench(
+    pub fn run(
         self: *Benchmark,
         comptime Runner: anytype,
         name: []const u8,
@@ -100,7 +100,7 @@ pub const Benchmark = struct {
                 .Union =>   |agr| agr.decls,
                 .Enum =>    |agr| agr.decls,
 
-                else => @compileError("runBench: `Runner` must be an Enum, Union or Struct, or a standalone function")
+                else => @compileError("run: `Runner` must be an Enum, Union or Struct, or a standalone function")
             };
 
             comptime var has_reset = false;
@@ -136,8 +136,7 @@ pub const Benchmark = struct {
 
             if (has_deinit) run_instance.deinit();
         } else {
-            // Not sure if it's actually possible to hit this branch?
-            @compileError("runBench: `Runner` must be an Enum, Union or Struct, or a standalone function with signature `fn (std.mem.Allocator) void`");
+            @compileError("run: `Runner` must be an Enum, Union or Struct, or a standalone function with signature `fn (std.mem.Allocator) void`");
         }
 
         const ret =  BenchmarkResult {
@@ -270,10 +269,6 @@ pub const Percentiles = struct {
     p99: u64,
     p995: u64,
 };
-
-/// BenchFunc is a function type that represents a benchmark function.
-/// It takes a pointer to a Benchmark object.
-pub const BenchFunc = fn (*Benchmark) void;
 
 /// BenchmarkResult stores the resulting computed metrics/statistics from a benchmark
 pub const BenchmarkResult = struct {

--- a/zbench.zig
+++ b/zbench.zig
@@ -18,7 +18,7 @@ pub const Benchmark = struct {
     /// Total number of operations performed during the benchmark.
     totalOperations: usize = 0,
     /// Minimum duration recorded among all runs (initially set to the maximum possible value).
-    minDuration: u64 = 18446744073709551615,
+    minDuration: u64 = std.math.maxInt(u64),
     /// Maximum duration recorded among all runs.
     maxDuration: u64 = 0,
     /// Total duration accumulated over all runs.
@@ -142,7 +142,12 @@ pub const Benchmark = struct {
         return Percentiles{ .p75 = p75, .p99 = p99, .p995 = p995 };
     }
 
-    pub fn prettyPrint(self: Benchmark) !void {
+    pub fn prettyPrintHeader() void {
+        std.debug.print("{s:<20} {s:<12} {s}\t{s:<10} {s:<10} {s:<10} {s}\n", .{ "benchmark", "time (avg)", "(min ............. max)", "p75", "p99", "p995", "runs" });
+        std.debug.print("-----------------------------------------------------------------------------------------------------\n", .{});
+    }
+
+    pub fn prettyPrintResult(self: Benchmark) !void {
         const percentiles = self.calculatePercentiles();
 
         var p75_buffer: [128]u8 = undefined;
@@ -163,9 +168,7 @@ pub const Benchmark = struct {
         var max_buffer: [128]u8 = undefined;
         const max_str = try format.duration(max_buffer[0..], self.maxDuration);
 
-        std.debug.print("{s:<20} {s:<12} {s:<20} {s:<10} {s:<10} {s:<10}\n", .{ "benchmark", "time (avg)", "(min ... max)", "p75", "p99", "p995" });
-        std.debug.print("--------------------------------------------------------------------------------------\n", .{});
-        std.debug.print("{s:<20} \x1b[33m{s:<12}\x1b[0m (\x1b[94m{s}\x1b[0m ... \x1b[95m{s}\x1b[0m) \x1b[90m{s:<10}\x1b[0m \x1b[90m{s:<10}\x1b[0m \x1b[90m{s:<10}\x1b[0m\n", .{ self.name, avg_str, min_str, max_str, p75_str, p99_str, p995_str });
+        std.debug.print("{s:<20} \x1b[33m{s:<12}\x1b[0m (\x1b[94m{s}\x1b[0m ... \x1b[95m{s}\x1b[0m)  \t\x1b[90m{s:<10}\x1b[0m \x1b[90m{s:<10}\x1b[0m \x1b[90m{s:<10} \x1b[90m{d}\x1b[0m\n", .{ self.name, avg_str, min_str, max_str, p75_str, p99_str, p995_str, self.totalOperations });
     }
 
     /// Calculate the average duration
@@ -295,5 +298,6 @@ pub fn run(comptime func: BenchFunc, bench: *Benchmark, benchResult: *BenchmarkR
     bench.setTotalOperations(bench.N);
     bench.report();
 
-    try bench.prettyPrint();
+    bench.prettyPrintHeader();
+    try bench.prettyPrintResult();
 }

--- a/zbench.zig
+++ b/zbench.zig
@@ -60,10 +60,10 @@ pub const Benchmark = struct {
     ///         fn (std.mem.Allocator) void         : Required
     ///
     ///     Aggregate (Struct/Union/Enum) with followin associated methods -
-    ///         fn init(std.mem.Allocator) !Self    : Required
-    ///         fn run(Self) void                   : Required
-    ///         fn deinit(Self) void                : Optional
-    ///         fn reset(Self) void                 : Optional
+    ///         pub fn init(std.mem.Allocator) !Self    : Required
+    ///         pub fn run(Self) void                   : Required
+    ///         pub fn deinit(Self) void                : Optional
+    ///         pub fn reset(Self) void                 : Optional
     ///
     /// NOTE:
     ///     `*Self` instead of `Self` also works for the above types.
@@ -308,4 +308,12 @@ pub const BenchmarkResult = struct {
 pub fn prettyPrintHeader() void {
     std.debug.print("{s:<20} {s:<12} {s}\t{s:<10} {s:<10} {s:<10} {s}\n", .{ "benchmark", "time (avg)", "(min ............. max)", "p75", "p99", "p995", "runs" });
     std.debug.print("-----------------------------------------------------------------------------------------------------\n", .{});
+}
+
+pub fn prettyPrintResults(results: []const BenchmarkResult, header: bool) !void {
+    if (header) {
+        prettyPrintHeader();
+    }
+
+    for (results) |res| try res.prettyPrint(false);
 }


### PR DESCRIPTION
Hey there,

I wanted to use zBench for my personal projects, but it lacked some functionality I wanted (mostly QOL). I've made the changes to my own fork and I'm fine with using that, however I thought at least I'd open a draft request here in case the changes I made can be helpful to the project. Note however, I've made some breaking API-changes, some of which can be reverted (deleted functions I didn't find useful and such), and I've moved up to compiler version 0.12.0 dev (it should be easy to move back to 0.11.0 though, I don't make use of any new big features). If you do want to include these changes we can coordinate reducing breakage as much as possible and reverting to zig 0.11.0, it shouldn't be difficult to do.

A quick summary of what has changed (of the top of my head):
- The `run` function is no longer standalone but an associated method of `Benchmark`. It now takes standalone functions as well as aggregate (ie. struct) runners which can initialize state along with a run function (among others).
- `BenchmarkResults` now takes on all the metrics/statistics generated by a benchmark-run and pretty-printing functionality moved to `BenchmarkResult`. The spacing is now fixed such that printing several results after one-another aligns nicely.
 - Names for the benchmarks are no longer associated with a `Benchmark` instance, but instead are passed along whenever we generate a `BenchmarkResult`. This makes it easier to reuse a `Benchmark` instance instead of generating a new one for every new benchmark.
 - A lot of usage-examples added to the README
 - A lot of tests added (not quite complete coverage yet)
 - One new example added
 - Added standard-deviation as a benchmark metric

Take a look at the Usage section of the README for the new examples. Again, I understand these are very big changes and most likely conflict with your vision of this project, but on the off-chance you want them included i'll open this as a draft.

Edit: Obviously if some of the features are desired but others aren't we can split off those into individual PR's that are easier to review (I'll have to see what workloads I can commit too ofc). 