### PR TITLE
Pretty print fixup

### DIFF
--- a/tests.zig
+++ b/tests.zig
@@ -12,8 +12,8 @@ test "Benchmark.calculateStd and Benchmark.calculateAverage" {
     try expectEq(@as(u64, 0), bench.calculateAverage());
     try expectEq(@as(u64, 0), bench.calculateStd());
 
-    try bench.durations.append(0);
-    try expectEq(@as(u64, 0), bench.calculateAverage());
+    try bench.durations.append(1);
+    try expectEq(@as(u64, 1), bench.calculateAverage());
     try expectEq(@as(u64, 0), bench.calculateStd());
 
     for (1..16) |i| try bench.durations.append(i);
@@ -23,4 +23,10 @@ test "Benchmark.calculateStd and Benchmark.calculateAverage" {
     for (16..101) |i| try bench.durations.append(i);
     try expectEq(@as(u64, 50), bench.calculateAverage());
     try expectEq(@as(u64, 29), bench.calculateStd());
+
+    bench.durations.clearRetainingCapacity();
+    for (0..10) |_| try bench.durations.append(1);
+
+    try expectEq(@as(u64, 1), bench.calculateAverage());
+    try expectEq(@as(u64, 0), bench.calculateStd());
 }

--- a/zbench.zig
+++ b/zbench.zig
@@ -166,9 +166,12 @@ pub const Benchmark = struct {
         var max_buffer: [128]u8 = undefined;
         const max_str = try format.duration(max_buffer[0..], self.maxDuration);
 
-        std.debug.print("{s:<20} {s:<12} {s:<20} {s:<10} {s:<10} {s:<10}\n", .{ "benchmark", "time (avg ± σ)", "(min ... max)", "p75", "p99", "p995" });
-        std.debug.print("--------------------------------------------------------------------------------------\n", .{});
-        std.debug.print("{s:<20} \x1b[33m{s:<12}\x1b[0m (\x1b[94m{s}\x1b[0m ... \x1b[95m{s}\x1b[0m) \x1b[90m{s:<10}\x1b[0m \x1b[90m{s:<10}\x1b[0m \x1b[90m{s:<10}\x1b[0m\n", .{ self.name, avg_std_str, min_str, max_str, p75_str, p99_str, p995_str });
+        var min_max_buffer: [128]u8 = undefined;
+        const min_max_str = try std.fmt.bufPrint(min_max_buffer[0..], "({s} ... {s})", .{ min_str, max_str });
+
+        std.debug.print("{s:<22} {s:<8} {s:<22} {s:<28} {s:<10} {s:<10} {s:<10}\n", .{ "benchmark", "runs", "time (avg ± σ)", "(min ... max)", "p75", "p99", "p995" });
+        std.debug.print("---------------------------------------------------------------------------------------------------------------\n", .{});
+        std.debug.print("{s:<22} \x1b[90m{d:<8} \x1b[33m{s:<22} \x1b[95m{s:<28} \x1b[90m{s:<10} {s:<10} {s:<10}\x1b[0m\n", .{ self.name, self.totalOperations, avg_std_str, min_max_str, p75_str, p99_str, p995_str });
     }
 
     /// Calculate the average duration


### PR DESCRIPTION
Part of #29. Makes it so that subsequent pretty-prints align nicely with eachother. Also now displays the number of runs performed in the pretty-print.