### PR TITLE
Overhaul zbench.run, add more tests and update examples

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -18,12 +18,7 @@ fn myBenchmark(_: *zbench.Benchmark) void {
 }
 
 test "bench test basic" {
-    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
-    var bench = try zbench.Benchmark.init("My Benchmark", test_allocator);
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
-    try zbench.run(myBenchmark, &bench, &benchmarkResults);
-    try benchmarkResults.prettyPrint();
+    var bench = try zbench.Benchmark.init(test_allocator);
+    defer bench.durations.deinit();
+    try (try bench.runSingle(myBenchmark, .{ .name = "Basic benchmark" })).prettyPrint(true);
 }

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -25,4 +25,5 @@ test "bench test basic" {
     };
     defer benchmarkResults.results.deinit();
     try zbench.run(myBenchmark, &bench, &benchmarkResults);
+    try benchmarkResults.prettyPrint();
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -28,4 +28,5 @@ test "bench test bubbleSort" {
     };
     defer benchmarkResults.results.deinit();
     try zbench.run(myBenchmark, &bench, &benchmarkResults);
+    try benchmarkResults.prettyPrint();
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -21,12 +21,7 @@ fn myBenchmark(_: *zbench.Benchmark) void {
 }
 
 test "bench test bubbleSort" {
-    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
-    var bench = try zbench.Benchmark.init("Bubble Sort Benchmark", test_allocator);
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
-    try zbench.run(myBenchmark, &bench, &benchmarkResults);
-    try benchmarkResults.prettyPrint();
+    var bench = try zbench.Benchmark.init(test_allocator);
+    defer bench.durations.deinit();
+    try (try bench.runSingle(myBenchmark, .{ .name = "Bubblesort benchmark" })).prettyPrint(true);
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -11,12 +11,7 @@ fn sleepBenchmark(_: *zbench.Benchmark) void {
 }
 
 test "bench test sleepy" {
-    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
-    var bench = try zbench.Benchmark.init("Sleep Benchmark", test_allocator);
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
-    try zbench.run(sleepBenchmark, &bench, &benchmarkResults);
-    try benchmarkResults.prettyPrint();
+    var bench = try zbench.Benchmark.init(test_allocator);
+    defer bench.durations.deinit();
+    try (try bench.runSingle(sleepBenchmark, .{ .name = "Sleepy benchmark" })).prettyPrint(true);
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -18,4 +18,5 @@ test "bench test sleepy" {
     };
     defer benchmarkResults.results.deinit();
     try zbench.run(sleepBenchmark, &bench, &benchmarkResults);
+    try benchmarkResults.prettyPrint();
 }

--- a/tests.zig
+++ b/tests.zig
@@ -117,10 +117,11 @@ test "Benchmark.run with struct runner with init, run and deinit" {
     // The runner should have been initialised as many times as it got deinitialised
     try expectEq(Runner.init_count, Runner.deinit_count);
 
-    // The runner should have been initialised as many times as max_runs + max_runs / 32 + 1
+    // The runner should have been initialised as many times as
+    // max_runs + max_runs / Benchmark.TRIAL_RUN_DIV + 1
     // FIXME: (The +1 is due to us initializing at the very end of the bench-loop despite not using
     // the runner afterwards..
-    try expectEq(Runner.init_count, 33 * run_args.max_runs / 32 + 1);
+    try expectEq(Runner.init_count, (Benchmark.TRIAL_RUN_DIV+1) * run_args.max_runs / Benchmark.TRIAL_RUN_DIV + 1);
 }
 
 test "Benchmark.run with complete bench-runner struct" {
@@ -166,7 +167,9 @@ test "Benchmark.run with complete bench-runner struct" {
     try expectEq(@as(usize, 1), Runner.deinit_count);
 
     // However it should have been reseted as many times as there are runs minus the trial-runs
-    try expectEq(run_args.max_runs, Runner.reset_count - run_args.max_runs / 32);
+    try expectEq(
+        run_args.max_runs, Runner.reset_count - run_args.max_runs / Benchmark.TRIAL_RUN_DIV
+    );
 }
 
 test "Benchmark.quickSort" {

--- a/tests.zig
+++ b/tests.zig
@@ -6,7 +6,7 @@ const expectEq = std.testing.expectEqual;
 const Benchmark = @import("./zbench.zig").Benchmark;
 
 test "Benchmark.calculateStd and Benchmark.calculateAverage" {
-    var bench = try Benchmark.init("test_bench", std.testing.allocator);
+    var bench = try Benchmark.init(test_alloc);
     defer bench.durations.deinit();
 
     try expectEq(@as(u64, 0), bench.calculateAverage());
@@ -30,3 +30,150 @@ test "Benchmark.calculateStd and Benchmark.calculateAverage" {
     try expectEq(@as(u64, 1), bench.calculateAverage());
     try expectEq(@as(u64, 0), bench.calculateStd());
 }
+
+test "Benchmark.run with standalone function" {
+    const run_args = Benchmark.RunArgs{ .max_runs = 1000, .max_time = std.math.maxInt(u64) };
+    var bench = try Benchmark.init(test_alloc);
+    defer bench.durations.deinit();
+
+    const Nested = struct {
+        pub fn run1(_: std.mem.Allocator) void {}
+        pub fn run2(_: *Benchmark) void {}
+    };
+
+    const res = try bench.runSingle(Nested.run1, run_args);
+    bench.reset();
+
+    // We set no time-limit, so it should perform all the runs requested
+    try expectEq(run_args.max_runs, res.total_runs);
+
+    // We also expect the Benchmark instance to be reset
+    try expectEq(@as(usize, 0), bench.total_runs);
+    try expectEq(@as(usize, std.math.maxInt(u64)), bench.min_duration);
+    try expectEq(@as(usize, 0), bench.max_duration);
+    try expectEq(@as(usize, 0), bench.total_duration);
+    try expectEq(@as(usize, 0), bench.durations.items.len);
+
+    // Make sure all runner-signatures are valid
+    _ = try bench.runSingle(Nested.run2, run_args);
+}
+
+test "Benchmark.run with enum runner with init and run" {
+    const run_args = Benchmark.RunArgs{ .max_runs = 1000, .max_time = std.math.maxInt(u64) };
+    var bench = try Benchmark.init(test_alloc);
+    defer bench.durations.deinit();
+
+    const Runner = enum {
+        const Self = @This();
+
+        Variant,
+
+        pub fn init(_: std.mem.Allocator) !Self {
+            return Self.Variant;
+        }
+        pub fn run(_: *Self) void {}
+    };
+
+    const res = try bench.runSingle(Runner, run_args);
+
+    try expectEq(run_args.max_runs, res.total_runs);
+}
+
+test "Benchmark.run with struct runner with init, run and deinit" {
+    const run_args = Benchmark.RunArgs{ .max_runs = 1000, .max_time = std.math.maxInt(u64) };
+    var bench = try Benchmark.init(test_alloc);
+    defer bench.durations.deinit();
+
+    const Runner = struct {
+        const Self = @This();
+        var init_count: usize = 0;
+        var deinit_count: usize = 0;
+
+        items: []u8,
+        alloc: std.mem.Allocator,
+
+        pub fn init(a: std.mem.Allocator) !Self {
+            Self.init_count += 1;
+            return Self{ .items = try a.alloc(u8, 5), .alloc = a };
+        }
+        pub fn run(self: Self) void {
+            if (self.items[1] >= self.items[2]) {
+                self.items[2] = self.items[3];
+            } else {
+                self.items[1] = self.items[4];
+            }
+        }
+
+        pub fn deinit(self: Self) void {
+            Self.deinit_count += 1;
+            self.alloc.free(self.items);
+        }
+    };
+
+    const res = try bench.runSingle(Runner, run_args);
+
+    try expectEq(run_args.max_runs, res.total_runs);
+
+    // The runner should have been initialised as many times as it got deinitialised
+    try expectEq(Runner.init_count, Runner.deinit_count);
+
+    // The runner should have been initialised as many times as max_runs + max_runs / 32 + 1
+    // FIXME: (The +1 is due to us initializing at the very end of the bench-loop despite not using
+    // the runner afterwards..
+    try expectEq(Runner.init_count, 33 * run_args.max_runs / 32 + 1);
+}
+
+test "Benchmark.run with complete bench-runner struct" {
+    const run_args = Benchmark.RunArgs{ .max_runs = 1000, .max_time = std.math.maxInt(u64) };
+    var bench = try Benchmark.init(test_alloc);
+    defer bench.durations.deinit();
+
+    const Runner = struct {
+        const Self = @This();
+        var init_count: usize = 0;
+        var reset_count: usize = 0;
+        var deinit_count: usize = 0;
+
+        items: []u64,
+        alloc: std.mem.Allocator,
+
+        pub fn init(a: std.mem.Allocator) !Self {
+            Self.init_count += 1;
+            return Self{ .items = try a.alloc(u64, 64), .alloc = a };
+        }
+        pub fn run(self: Self) void {
+            for (self.items, 0..) |*item, i| {
+                if (item.* <= i) item.* = i else item.* = 0;
+            }
+        }
+        pub fn deinit(self: Self) void {
+            Self.deinit_count += 1;
+            self.alloc.free(self.items);
+        }
+        pub fn reset(self: Self) void {
+            Self.reset_count += 1;
+            @memset(self.items, 0);
+        }
+    };
+
+    const res = try bench.runSingle(Runner, run_args);
+    try expectEq(run_args.max_runs, res.total_runs);
+
+    // Since a reset function was provided the runner should only be inited once
+    try expectEq(@as(usize, 1), Runner.init_count);
+
+    // Since a reset function was provided the runner should only be deinited once
+    try expectEq(@as(usize, 1), Runner.deinit_count);
+
+    // However it should have been reseted as many times as there are runs minus the trial-runs
+    try expectEq(run_args.max_runs, Runner.reset_count - run_args.max_runs / 32);
+}
+
+test "Benchmark.quickSort" {
+    comptime var nums = [_]u64{ 2, 3, 4, 6, 1, 8, 0, 5 };
+    comptime Benchmark.quickSort(&nums, 0, nums.len - 1);
+
+    try expectEq([_]u64{ 0, 1, 2, 3, 4, 5, 6, 8 }, nums);
+}
+
+// TODO: Add a test for Benchmark.calculatePercentiles

--- a/zbench.zig
+++ b/zbench.zig
@@ -29,6 +29,9 @@ pub const Benchmark = struct {
         alloc: ?std.mem.Allocator = null,
     };
 
+    /// Divisor used to decide the number of trial runs to perform
+    pub const TRIAL_RUN_DIV: u64 = 32;
+
     /// Number of runs (or iterations) to be performed in the benchmark.
     N: usize = 1,
     /// Timer used to track the duration of the benchmark.
@@ -134,8 +137,10 @@ pub const Benchmark = struct {
 
         // First we do some trial runs to warm up the system and get a time-estimate
         // of how long each benchmar-run will take including init/deinit or reset
-        const trial_runs = @max(run_args.max_runs / 32, 10);
-        const trial_time = @max(run_args.max_time / 32, 5_000);
+        // The idea is to do a fraction of the total number of runs, hence division by
+        // `TRIAL_RUN_DIV`
+        const trial_runs = @max(run_args.max_runs / TRIAL_RUN_DIV, 10);
+        const trial_time = @max(run_args.max_time / TRIAL_RUN_DIV, 10_000);
         while (self.total_duration < trial_time and self.total_runs < trial_runs) {
             // All of these branches evaluate at compile-time!
             self.start();


### PR DESCRIPTION
    zbench.run now becomes Benchmark.run and notably accepts two new
    parameters: RunArgs and Runner.
    
    - RunArgs contains upper-boundaries for run/iteration and time limits
      for the benchmark, as well as an optional allocator type to be used
      by the benchmark (in the future more configuration-parameters can be
      added here).
    
    - Runner is now a generic type that can be a function with signature
      fn (*zbench.Benchmark) void (old functionality) or
      fn(std.mem.Allocator) void, or a struct/enum/union with the methods
      init, run, reset and deinit. The latter construct allows a user
      to split initialization code from run code (the part they wish to
      benchmark), as well as decide how state should be reset between runs.
    
    For convenience the Benchmark.runSingle function has been added. This
    function returns a BenchmarkResult directly instead of storing it in
    an allocated BenchmarkResults type