### PR TITLE
Added init/deinit to BenchmarkResults and updated examples

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -19,11 +19,10 @@ fn myBenchmark(_: *zbench.Benchmark) void {
 
 test "bench test basic" {
     const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
+    var benchmarkResults = zbench.BenchmarkResults.init(resultsAlloc);
+    defer benchmarkResults.deinit();
     var bench = try zbench.Benchmark.init("My Benchmark", test_allocator, .{ .iterations = 10 });
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
+
     try zbench.run(myBenchmark, &bench, &benchmarkResults);
     try benchmarkResults.prettyPrint();
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -22,11 +22,10 @@ fn myBenchmark(_: *zbench.Benchmark) void {
 
 test "bench test bubbleSort" {
     const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
+    var benchmarkResults = zbench.BenchmarkResults.init(resultsAlloc);
+    defer benchmarkResults.deinit();
     var bench = try zbench.Benchmark.init("Bubble Sort Benchmark", test_allocator, .{});
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
+
     try zbench.run(myBenchmark, &bench, &benchmarkResults);
     try benchmarkResults.prettyPrint();
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -12,11 +12,10 @@ fn sleepBenchmark(_: *zbench.Benchmark) void {
 
 test "bench test sleepy" {
     const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
+    var benchmarkResults = zbench.BenchmarkResults.init(resultsAlloc);
+    defer benchmarkResults.deinit();
     var bench = try zbench.Benchmark.init("Sleep Benchmark", test_allocator, .{});
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
+
     try zbench.run(sleepBenchmark, &bench, &benchmarkResults);
     try benchmarkResults.prettyPrint();
 }

--- a/zbench.zig
+++ b/zbench.zig
@@ -244,11 +244,26 @@ pub fn prettyPrintHeader(writer: anytype) !void {
 /// It provides functionality to format and print these results.
 pub const BenchmarkResults = struct {
     const Color = c.Color;
+    const BufferedStdoutWriter = std.io.BufferedWriter(1024, @TypeOf(std.io.getStdOut().writer()));
 
     /// A dynamic list of BenchmarkResult objects.
     results: std.ArrayList(BenchmarkResult),
     /// A handle to a buffered stdout-writer. Used for printing-operations
-    out_stream: std.io.BufferedWriter(1024, @TypeOf(std.io.getStdOut().writer())) = .{ .unbuffered_writer = std.io.getStdOut().writer() },
+    out_stream: BufferedStdoutWriter,
+
+    // NOTE: This init function is technically not needed however it was added to circumvent a (most likely) bug
+    // in the 0.11.0 compiler (see issue #49). In the future we may want to remove this.
+    pub fn init(results: std.ArrayList(BenchmarkResult)) BenchmarkResults {
+        return BenchmarkResults{
+            .results = results,
+            .out_stream = .{ .unbuffered_writer = std.io.getStdOut().writer() },
+        };
+    }
+
+    pub fn deinit(self: *BenchmarkResults) void {
+        // self.out_stream.flush();
+        self.results.deinit();
+    }
 
     /// Determines the color representation based on the total-time of the benchmark.
     /// total_time: The total-time to evaluate.


### PR DESCRIPTION
This was done to circumvent hendriknielaender#49, which is (most likely) caused by a bug in the compiler. Closes #49.