### PR TITLE
Remove dead function zbench.prettyPrintHeader

### DIFF
--- a/zbench.zig
+++ b/zbench.zig
@@ -232,16 +232,6 @@ pub const BenchmarkResult = struct {
     }
 };
 
-/// Pretty-prints the header for the result pretty-print table
-/// writer: Type that has the associated method print (for example std.io.getStdOut.writer())
-pub fn prettyPrintHeader(writer: anytype) !void {
-    try writer.print(
-        "\n{s:<22} {s:<8} {s:<14} {s:<22} {s:<28} {s:<10} {s:<10} {s:<10}\n",
-        .{ "benchmark", "runs", "total time", "time/run (avg ± σ)", "(min ... max)", "p75", "p99", "p995" },
-    );
-    try writer.print("-----------------------------------------------------------------------------------------------------------------------------\n", .{});
-}
-
 /// BenchmarkResults acts as a container for multiple benchmark results.
 /// It provides functionality to format and print these results.
 pub const BenchmarkResults = struct {


### PR DESCRIPTION
This function was moved to format.zig, but we had forgotten to remove it from zbench.zig