### PR TITLE
feat(benchmark): add lifecycle hooks for enhanced benchmark control

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ pub const Config = struct {
     iterations: u16 = 0,
     max_iterations: u16 = 16384,
     time_budget: u64 = 2e9, // 2 seconds
+    hooks: LifecycleHooks = .{},
     display_system_info: bool = false,
 };
 ```
@@ -127,6 +128,7 @@ pub const Config = struct {
 - `iterations`: The number of iterations the benchmark has been run. This field is usually managed by zBench itself.
 - `max_iterations`: Set the maximum number of iterations for a benchmark. Useful for controlling long-running benchmarks.
 - `time_budget`: Define a time budget for the benchmark in nanoseconds. Helps in limiting the total execution time of the benchmark.
+- `hooks`: Set `beforeAll`, `afterAll`, `beforeEach`, and `afterEach` hooks.
 - `display_system_info`: Enable or disable displaying system information alongside the benchmark results.
 
 ### Compatibility Notes

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -13,6 +13,14 @@ fn helloWorld() []const u8 {
     return "Hello, world!";
 }
 
+fn beforeAllHook() void {
+    std.debug.print("Starting benchmarking...\n", .{});
+}
+
+fn afterAllHook() void {
+    std.debug.print("Finished benchmarking.\n", .{});
+}
+
 fn myBenchmark(_: *zbench.Benchmark) void {
     _ = helloWorld();
 }
@@ -21,7 +29,14 @@ test "bench test basic" {
     const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
     var benchmarkResults = zbench.BenchmarkResults.init(resultsAlloc);
     defer benchmarkResults.deinit();
-    var bench = try zbench.Benchmark.init("My Benchmark", test_allocator, .{ .iterations = 10, .display_system_info = true });
+    var bench = try zbench.Benchmark.init("My Benchmark", test_allocator, .{
+        .iterations = 10,
+        .display_system_info = true,
+        .hooks = .{
+            .beforeAll = beforeAllHook,
+            .afterAll = afterAllHook,
+        },
+    });
 
     try zbench.run(myBenchmark, &bench, &benchmarkResults);
     try benchmarkResults.prettyPrint();


### PR DESCRIPTION
## Add Lifecycle Hooks

This PR introduces lifecycle hooks, providing users with greater control and flexibility over their benchmark setup and teardown processes. These hooks allow for custom actions at various stages of the benchmarking lifecycle, enabling precise environment management and setup/teardown operations.

### New Features:

- **Lifecycle Hooks**: Implement `beforeAll`, `afterAll`, `beforeEach`, and `afterEach` hooks.
  - `beforeAll`: Executes once before all benchmarks begin.
  - `afterAll`: Executes once after all benchmarks have completed.
  - `beforeEach`: Executes before each individual benchmark iteration.
  - `afterEach`: Executes after each individual benchmark iteration.

### Use Cases:

These hooks are particularly beneficial for complex benchmarks requiring specific setup and teardown operations, ensuring each test runs under the right conditions and managing resources properly.

### Implementation:

Hooks are optional and easy to integrate into existing tests with minimal configuration, defined within the `LifecycleHooks` struct and included in the benchmark `Config` struct. This enhancement aims to provide a seamless and flexible user experience for benchmarking.

### Example Usage:

```zig
const hooks = .{
    .beforeAll = fn() void { /* global setup */ },
    .afterAll = fn() void { /* global teardown */ },
    .beforeEach = fn() void { /* per-test setup */ },
    .afterEach = fn() void { /* per-test teardown */ },
};
var config = Benchmark.Config{ .hooks = hooks };
```

closes https://github.com/hendriknielaender/zBench/issues/41