### PR TITLE
Fix formatting durations with fractions with leading zeroes

### DIFF
--- a/util/format.zig
+++ b/util/format.zig
@@ -2,23 +2,21 @@ const std = @import("std");
 const Color = @import("./color.zig").Color;
 const log = std.log.scoped(.zbench_format);
 
-pub fn duration(buffer: []u8, d: u64) ![]u8 {
+pub fn duration(buffer: []u8, nanoseconds: u64) ![]u8 {
     const units = [_][]const u8{ "ns", "µs", "ms", "s" };
 
-    var scaledDuration: u64 = d;
+    var scaled: f64 = @floatFromInt(nanoseconds);
     var unitIndex: usize = 0;
 
-    var fractionalPart: u64 = 0;
-
-    while (scaledDuration >= 1_000 and unitIndex < units.len - 1) {
-        fractionalPart = scaledDuration % 1_000;
-        scaledDuration /= 1_000;
+    while (scaled >= 1000.0 and unitIndex < units.len - 1) {
+        scaled /= 1000.0;
         unitIndex += 1;
     }
 
-    const formatted = try std.fmt.bufPrint(buffer, "{d}.{d}{s}", .{ scaledDuration, fractionalPart, units[unitIndex] });
-
-    return formatted;
+    return if (0 < unitIndex) try std.fmt.bufPrint(buffer, "{d:.3}{s}", .{
+        scaled,
+        units[unitIndex],
+    }) else try std.fmt.bufPrint(buffer, "{d}ns", .{nanoseconds});
 }
 
 pub fn memorySize(bytes: u64, allocator: std.mem.Allocator) ![]const u8 {

--- a/util/format_test.zig
+++ b/util/format_test.zig
@@ -8,27 +8,42 @@ test "duration" {
 
     {
         const result = try format.duration(buffer[0..], 1);
-        try std.testing.expectEqualSlices(u8, "1.0ns", result);
+        try std.testing.expectEqualSlices(u8, "1ns", result);
     }
 
     {
         const result = try format.duration(buffer[0..], 999);
-        try std.testing.expectEqualSlices(u8, "999.0ns", result);
+        try std.testing.expectEqualSlices(u8, "999ns", result);
     }
 
     {
         const result = try format.duration(buffer[0..], 1000);
-        try std.testing.expectEqualSlices(u8, "1.0µs", result);
+        try std.testing.expectEqualSlices(u8, "1.000µs", result);
     }
 
     {
         const result = try format.duration(buffer[0..], 1000000);
-        try std.testing.expectEqualSlices(u8, "1.0ms", result);
+        try std.testing.expectEqualSlices(u8, "1.000ms", result);
     }
 
     {
         const result = try format.duration(buffer[0..], 1000000000);
-        try std.testing.expectEqualSlices(u8, "1.0s", result);
+        try std.testing.expectEqualSlices(u8, "1.000s", result);
+    }
+
+    {
+        const result = try format.duration(buffer[0..], 1234567890);
+        try std.testing.expectEqualSlices(u8, "1.235s", result);
+    }
+
+    {
+        const result = try format.duration(buffer[0..], 1023456789);
+        try std.testing.expectEqualSlices(u8, "1.023s", result);
+    }
+
+    {
+        const result = try format.duration(buffer[0..], 1999999999);
+        try std.testing.expectEqualSlices(u8, "2.000s", result);
     }
 
     {


### PR DESCRIPTION
The `duration` formatting function gives incorrect results for values with leading zeroes in the fraction component, for example I see this result:

```
benchmark              runs     total time     time/run (avg ± σ)     (min ... max)                p75        p99        p995      
-----------------------------------------------------------------------------------------------------------------------------
1 sphere               10       20.979s        2.97s ± 80.398ms       (2.7s ... 2.294s)            2.133s     2.70s      2.70s      
```

The total time is 20.9 seconds, but when divided by ten for the average it gives 2.9 seconds, not 2.09. Also see the min, max, and percentiles not making sense. This does change the output for cases like 1.0s to 1.000s, but I think it's better to show the precision in that case anyway.

Another issue was the division was always floored since it was using integer division, I've changed to using a float for the division down to a nice unit and using `format`'s builtin rounding off at the time of printing.

Finally, for nanoseconds there's no actual fractional precision, so I added a special case for that to only show whole nanoseconds.

I've added tests for these cases as well of course.