### PR TITLE
Fix percentile calculation, there was an issue with sorting

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -38,6 +38,7 @@ fn setupTesting(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builti
     const test_files = [_]struct { name: []const u8, path: []const u8 }{
         .{ .name = "tests", .path = "tests.zig" },
         .{ .name = "format_test", .path = "util/format_test.zig" },
+        .{ .name = "quicksort", .path = "util/quicksort.zig" },
     };
 
     const test_step = b.step("test", "Run library tests");

--- a/tests.zig
+++ b/tests.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const test_alloc = std.testing.allocator;
 const print = std.debug.print;
 const expectEq = std.testing.expectEqual;
+const expectEqDeep = std.testing.expectEqualDeep;
 
 const Benchmark = @import("./zbench.zig").Benchmark;
 
@@ -29,4 +30,22 @@ test "Benchmark.calculateStd and Benchmark.calculateAverage" {
 
     try expectEq(@as(u64, 1), bench.calculateAverage());
     try expectEq(@as(u64, 0), bench.calculateStd());
+}
+
+test "Benchmark.calculatePercentiles" {
+    const P = Benchmark.Percentiles;
+    var bench = try Benchmark.init("test_bench", std.testing.allocator, .{});
+    defer bench.durations.deinit();
+
+    for (0..100) |i| try bench.durations.append(i);
+    try expectEq(
+        P{ .p75 = 75, .p99 = 99, .p995 = 99 },
+        bench.calculatePercentiles(),
+    );
+
+    std.mem.reverse(u64, bench.durations.items);
+    try expectEq(
+        P{ .p75 = 75, .p99 = 99, .p995 = 99 },
+        bench.calculatePercentiles(),
+    );
 }


### PR DESCRIPTION
The last item of the durations array was being left out of the sort, and sometimes I was seeing larger p75 values than p995, which is nonsensical. I've fixed the issue and added some tests and asserts that check for sanity.

The average and standard deviation functions looked like they could use some tweaks too.