### PR TITLE
Add an incremental API for running benchmarks

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -60,8 +60,11 @@ fn setupExamples(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
     const example_names = [_][]const u8{
         "basic",
         "bubble_sort",
+        "hooks",
         "parameterised",
+        "progress",
         "sleep",
+        "systeminfo",
     };
 
     for (example_names) |example_name| {

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -27,7 +27,5 @@ test "bench test bubbleSort" {
 
     try bench.add("Bubble Sort Benchmark", myBenchmark, .{});
 
-    const results = try bench.run();
-    defer results.deinit();
-    try results.prettyPrint(stdout, true);
+    try bench.run(stdout);
 }

--- a/examples/hooks.zig
+++ b/examples/hooks.zig
@@ -1,6 +1,14 @@
 const std = @import("std");
 const zbench = @import("zbench");
 
+fn beforeAllHook() void {
+    std.debug.print("Starting benchmarking...\n", .{});
+}
+
+fn afterAllHook() void {
+    std.debug.print("Finished benchmarking.\n", .{});
+}
+
 fn myBenchmark(_: std.mem.Allocator) void {
     var result: usize = 0;
     for (0..1_000_000) |i| {
@@ -9,11 +17,17 @@ fn myBenchmark(_: std.mem.Allocator) void {
     }
 }
 
-test "bench test basic" {
+test "bench test hooks" {
     const stdout = std.io.getStdOut().writer();
     var bench = zbench.Benchmark.init(std.testing.allocator, .{});
     defer bench.deinit();
 
-    try bench.add("My Benchmark", myBenchmark, .{});
+    try bench.add("My Benchmark", myBenchmark, .{
+        .iterations = 100,
+        .hooks = .{
+            .before_all = beforeAllHook,
+            .after_all = afterAllHook,
+        },
+    });
     try bench.run(stdout);
 }

--- a/examples/parameterised.zig
+++ b/examples/parameterised.zig
@@ -11,7 +11,10 @@ const MyBenchmark = struct {
 
     pub fn run(self: MyBenchmark, _: std.mem.Allocator) void {
         var result: usize = 0;
-        for (0..self.loops) |i| result += i * i;
+        for (0..self.loops) |i| {
+            std.mem.doNotOptimizeAway(i);
+            result += i * i;
+        }
     }
 };
 
@@ -23,8 +26,6 @@ test "bench test parameterised" {
     try bench.addParam("My Benchmark 1", &MyBenchmark.init(100_000), .{});
     try bench.addParam("My Benchmark 2", &MyBenchmark.init(200_000), .{});
 
-    const results = try bench.run();
-    defer results.deinit();
     try stdout.writeAll("\n");
-    try results.prettyPrint(stdout, true);
+    try bench.run(stdout);
 }

--- a/examples/progress.zig
+++ b/examples/progress.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const zbench = @import("zbench");
+const test_allocator = std.testing.allocator;
+
+fn myBenchmark1(_: std.mem.Allocator) void {
+    var result: usize = 0;
+    for (0..100_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
+}
+
+fn myBenchmark2(_: std.mem.Allocator) void {
+    var result: usize = 0;
+    for (0..200_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
+}
+
+test "bench test progress" {
+    const stdout = std.io.getStdOut().writer();
+    var bench = zbench.Benchmark.init(test_allocator, .{});
+    defer bench.deinit();
+
+    try bench.add("My Benchmark 1", myBenchmark1, .{});
+    try bench.add("My Benchmark 2", myBenchmark2, .{});
+
+    var progress = std.Progress{};
+    const progress_node = progress.start("", 0);
+    defer progress_node.end();
+
+    try stdout.writeAll("\n");
+    try bench.prettyPrintHeader(stdout);
+    var iter = try bench.iterator();
+    while (try iter.next()) |step| switch (step) {
+        .progress => |p| {
+            progress_node.setEstimatedTotalItems(p.total_runs);
+            progress_node.setCompletedItems(p.completed_runs);
+            progress_node.setName(p.current_name);
+            progress.maybeRefresh();
+        },
+        .result => |x| {
+            defer x.deinit();
+            progress_node.setName("");
+            progress_node.setEstimatedTotalItems(0);
+            progress_node.setCompletedItems(0);
+            progress.refresh();
+            try x.prettyPrint(stdout, true);
+        },
+    };
+}

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -2,22 +2,14 @@ const std = @import("std");
 const zbench = @import("zbench");
 const test_allocator = std.testing.allocator;
 
-fn sooSleepy() void {
-    std.time.sleep(100_000_000);
-}
-
 fn sleepBenchmark(_: std.mem.Allocator) void {
-    _ = sooSleepy();
+    std.time.sleep(100_000_000);
 }
 
 test "bench test sleepy" {
     const stdout = std.io.getStdOut().writer();
     var bench = zbench.Benchmark.init(test_allocator, .{});
     defer bench.deinit();
-
     try bench.add("Sleep Benchmark", sleepBenchmark, .{});
-
-    const results = try bench.run();
-    defer results.deinit();
-    try results.prettyPrint(stdout, true);
+    try bench.run(stdout);
 }

--- a/examples/systeminfo.zig
+++ b/examples/systeminfo.zig
@@ -9,10 +9,13 @@ fn myBenchmark(_: std.mem.Allocator) void {
     }
 }
 
-test "bench test basic" {
+test "bench test system info" {
     const stdout = std.io.getStdOut().writer();
     var bench = zbench.Benchmark.init(std.testing.allocator, .{});
     defer bench.deinit();
+
+    const sysinfo = try bench.getSystemInfo();
+    try std.fmt.format(stdout, "\n{}\n", .{sysinfo});
 
     try bench.add("My Benchmark", myBenchmark, .{});
     try bench.run(stdout);

--- a/zbench.zig
+++ b/zbench.zig
@@ -10,7 +10,7 @@ const format = @import("./util/format.zig");
 const Optional = @import("./util/optional.zig").Optional;
 const optional = @import("./util/optional.zig").optional;
 const platform = @import("./util/platform.zig");
-const runner = @import("./util/runner.zig");
+const Runner = @import("./util/runner.zig");
 
 /// Hooks containing optional hooks for lifecycle events in benchmarking.
 /// Each field in this struct is a nullable function pointer.
@@ -128,25 +128,120 @@ pub const Benchmark = struct {
         });
     }
 
-    /// Run all benchmarks and collect timing information.
-    pub fn run(self: Benchmark) !Results {
-        const n_benchmarks = self.benchmarks.items.len;
-        const results = try self.allocator.alloc(Result, n_benchmarks);
-        for (self.benchmarks.items, results) |b, *result| {
-            if (b.config.hooks.before_all) |hook| hook();
-            defer if (b.config.hooks.after_all) |hook| hook();
+    /// An incremental API for getting progress updates on running benchmarks.
+    pub const Iterator = struct {
+        allocator: std.mem.Allocator,
+        b: *const Benchmark,
+        remaining: []const Definition,
+        runner: ?Runner,
 
-            var r = try runner.init(
-                self.allocator,
-                b.config.iterations,
-                b.config.max_iterations,
-                b.config.time_budget_ns,
-            );
-            errdefer r.abort();
-            while (try r.next(try self.runFunc(b))) |_| {}
-            result.* = try Result.init(self.allocator, b.name, try r.finish());
+        /// A summary of progress through benchmarking a function. The
+        /// total_runs field may vary over time as the runner calibrates how
+        /// many runs to perform.
+        pub const Progress = struct {
+            total_benchmarks: usize,
+            completed_benchmarks: usize,
+            current_name: []const u8,
+            total_runs: usize,
+            completed_runs: usize,
+        };
+
+        /// A progress update from the iterator; reports either that it's some
+        /// way through benchmarking a function, or it has collected the results
+        /// for a benchmark.
+        pub const Step = union(enum) {
+            progress: Progress,
+            result: Result,
+        };
+
+        /// Get the next response.
+        pub fn next(self: *Iterator) !?Step {
+            if (self.remaining.len == 0) return null;
+
+            var runner: *Runner = if (self.runner) |*r| r else blk: {
+                const config = self.remaining[0].config;
+                if (config.hooks.before_all) |hook| hook();
+                self.runner = try Runner.init(
+                    self.allocator,
+                    config.iterations,
+                    config.max_iterations,
+                    config.time_budget_ns,
+                );
+                break :blk &self.runner.?;
+            };
+
+            const runner_step = blk: {
+                errdefer self.abort();
+                const ns = try self.b.runFunc(self.remaining[0]);
+                break :blk try runner.next(ns);
+            };
+            if (runner_step) |_| {
+                const total_benchmarks = self.b.benchmarks.items.len;
+                const remaining_benchmarks = self.remaining.len;
+                const runner_status = runner.status();
+                return Step{ .progress = Progress{
+                    .total_benchmarks = total_benchmarks,
+                    .completed_benchmarks = total_benchmarks - remaining_benchmarks,
+                    .current_name = self.remaining[0].name,
+                    .total_runs = runner_status.total_runs,
+                    .completed_runs = runner_status.completed_runs,
+                } };
+            } else {
+                defer self.runner = null;
+                defer self.remaining = self.remaining[1..];
+                if (self.remaining[0].config.hooks.after_all) |hook| hook();
+                return Step{ .result = try Result.init(
+                    self.allocator,
+                    self.remaining[0].name,
+                    try runner.finish(),
+                ) };
+            }
         }
-        return Results{ .allocator = self.allocator, .results = results };
+
+        /// Clean up the iterator if an error has occurred.
+        pub fn abort(self: *Iterator) void {
+            if (self.runner) |*r| {
+                if (self.remaining[0].config.hooks.after_all) |hook| hook();
+                r.abort();
+            }
+        }
+    };
+
+    /// Run all benchmarks using an iterator, collecting progress information
+    /// incrementally.
+    pub fn iterator(self: Benchmark) !Iterator {
+        return Iterator{
+            .allocator = self.allocator,
+            .b = &self,
+            .remaining = self.benchmarks.items,
+            .runner = null,
+        };
+    }
+
+    /// Run all benchmarks and collect timing information.
+    pub fn run(self: Benchmark, writer: anytype) !void {
+        var progress = std.Progress{};
+        const progress_node = progress.start("", 0);
+        defer progress_node.end();
+
+        try self.prettyPrintHeader(writer);
+        var iter = try self.iterator();
+        while (try iter.next()) |step| switch (step) {
+            .progress => |p| {
+                progress_node.setEstimatedTotalItems(p.total_runs);
+                progress_node.setCompletedItems(p.completed_runs);
+                progress_node.setName(p.current_name);
+                progress.maybeRefresh();
+            },
+            .result => |x| {
+                defer x.deinit();
+                progress_node.setName("");
+                progress_node.setEstimatedTotalItems(0);
+                progress_node.setCompletedItems(0);
+                progress.refresh();
+                try x.prettyPrint(writer, true);
+            },
+        };
     }
 
     /// Run and time a benchmark function once, as well as running before and
@@ -171,37 +266,6 @@ pub const Benchmark = struct {
     /// Get a copy of the system information, cpu type, cores, memory, etc.
     pub fn getSystemInfo(_: Benchmark) !platform.OsInfo {
         return try platform.getSystemInfo();
-    }
-};
-
-/// A collection of the results of each benchmark. The results are available in
-/// the `results` array but they can be collectively pretty printed and
-/// deallocated with this structure.
-pub const Results = struct {
-    allocator: std.mem.Allocator,
-    results: []Result,
-
-    pub fn deinit(self: Results) void {
-        for (self.results) |r| r.deinit();
-        self.allocator.free(self.results);
-    }
-
-    /// Formats and prints the benchmark results in a human readable format.
-    /// writer: Type that has the associated method print (for example std.io.getStdOut.writer())
-    /// colors: Whether to pretty-print with ANSI colors or not.
-    pub fn prettyPrint(self: Results, writer: anytype, colors: bool) !void {
-        try format.prettyPrintHeader(writer);
-        for (self.results) |r| try r.prettyPrint(writer, colors);
-    }
-
-    /// Prints the benchmark results in a machine readable JSON format.
-    pub fn writeJSON(self: Results, writer: anytype) !void {
-        try writer.writeAll("{\"benchmarks\": [\n");
-        for (self.results, 0..) |r, i| {
-            if (i != 0) try writer.writeAll(", ");
-            try r.writeJSON(writer);
-        }
-        try writer.writeAll("]}\n");
     }
 };
 


### PR DESCRIPTION
Allows to get results as they become available and show a progress bar type display, and allows to limit memory use by freeing results when they're received.