### PR TITLE
Parameterised benchmarks

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -60,6 +60,7 @@ fn setupExamples(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
     const example_names = [_][]const u8{
         "basic",
         "bubble_sort",
+        "parameterised",
         "sleep",
     };
 

--- a/examples/parameterised.zig
+++ b/examples/parameterised.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const zbench = @import("zbench");
+const test_allocator = std.testing.allocator;
+
+const MyBenchmark = struct {
+    loops: usize,
+
+    fn init(loops: usize) MyBenchmark {
+        return .{ .loops = loops };
+    }
+
+    pub fn run(self: MyBenchmark, _: std.mem.Allocator) void {
+        var result: usize = 0;
+        for (0..self.loops) |i| result += i * i;
+    }
+};
+
+test "bench test parameterised" {
+    const stdout = std.io.getStdOut().writer();
+    var bench = zbench.Benchmark.init(test_allocator, .{});
+    defer bench.deinit();
+
+    try bench.addParam("My Benchmark 1", &MyBenchmark.init(100_000), .{});
+    try bench.addParam("My Benchmark 2", &MyBenchmark.init(200_000), .{});
+
+    const results = try bench.run();
+    defer results.deinit();
+    try stdout.writeAll("\n");
+    try results.prettyPrint(stdout, true);
+}


### PR DESCRIPTION
This implementation is pretty simple and allows any number and type of parameters to be used, I think the API is pretty pleasant too. Despite the `@ptrCast`s and `anyopaque`s I'm pretty confident it's type safe as long as benchmarks are always added using the API functions.

close https://github.com/hendriknielaender/zBench/issues/55