### PR TITLE
feat(benchmark): add summary output for benchmark comparisons

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -59,6 +59,7 @@ fn setupExamples(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
     const example_step = b.step("test_examples", "Build examples");
     const example_names = [_][]const u8{
         "basic",
+        "summary",
         "bubble_sort",
         "sleep",
     };

--- a/examples/summary.zig
+++ b/examples/summary.zig
@@ -4,15 +4,24 @@ const test_allocator = std.testing.allocator;
 
 fn fastFunction(_: std.mem.Allocator) void {
     var result: usize = 0;
-    for (0..1000) |i| result += i * i;
+    for (0..1_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
 }
 fn mediumFunction(_: std.mem.Allocator) void {
     var result: usize = 0;
-    for (0..20000) |i| result += i * i;
+    for (0..20_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
 }
 fn slowFunction(_: std.mem.Allocator) void {
     var result: usize = 0;
-    for (0..300000) |i| result += i * i;
+    for (0..300_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
 }
 
 test "bench test summary" {
@@ -32,9 +41,6 @@ test "bench test summary" {
         .iterations = 10,
     });
 
-    const results = try bench.run();
-    defer results.deinit();
-
-    try results.prettyPrint(stdout, true);
-    try results.printSummary(stdout);
+    try stdout.writeAll("\n");
+    try zbench.prettyPrintHeader(stdout);
 }

--- a/examples/summary.zig
+++ b/examples/summary.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const zbench = @import("zbench");
+const test_allocator = std.testing.allocator;
+
+fn function1() []const u8 {
+    var result: usize = 0;
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        const square = i * i;
+        result += square;
+    }
+
+    return "Hello, world!";
+}
+
+fn function2() []const u8 {
+    var result: usize = 0;
+    var i: usize = 0;
+    while (i < 20000) : (i += 1) {
+        const square = i * i;
+        result += square;
+    }
+
+    return "Hello, world!";
+}
+
+fn function3() []const u8 {
+    var result: usize = 0;
+    var i: usize = 0;
+    while (i < 300000) : (i += 1) {
+        const square = i * i;
+        result += square;
+    }
+
+    return "Hello, world!";
+}
+
+fn fn1(_: std.mem.Allocator) void {
+    _ = function1();
+}
+
+fn fn2(_: std.mem.Allocator) void {
+    _ = function2();
+}
+
+fn fn3(_: std.mem.Allocator) void {
+    _ = function3();
+}
+
+test "bench test basic" {
+    const stdout = std.io.getStdOut().writer();
+    var bench = zbench.Benchmark.init(test_allocator, .{});
+    defer bench.deinit();
+
+    try bench.add("fast function", fn1, .{
+        .iterations = 10,
+    });
+
+    try bench.add("medium fast function", fn2, .{
+        .iterations = 10,
+    });
+
+    try bench.add("slow function", fn3, .{
+        .iterations = 10,
+    });
+
+    const results = try bench.run();
+    defer results.deinit();
+
+    try results.prettyPrint(stdout, true);
+    try results.printSummary(stdout);
+}

--- a/examples/summary.zig
+++ b/examples/summary.zig
@@ -2,65 +2,33 @@ const std = @import("std");
 const zbench = @import("zbench");
 const test_allocator = std.testing.allocator;
 
-fn function1() []const u8 {
+fn fastFunction(_: std.mem.Allocator) void {
     var result: usize = 0;
-    var i: usize = 0;
-    while (i < 1000) : (i += 1) {
-        const square = i * i;
-        result += square;
-    }
-
-    return "Hello, world!";
+    for (0..1000) |i| result += i * i;
 }
-
-fn function2() []const u8 {
+fn mediumFunction(_: std.mem.Allocator) void {
     var result: usize = 0;
-    var i: usize = 0;
-    while (i < 20000) : (i += 1) {
-        const square = i * i;
-        result += square;
-    }
-
-    return "Hello, world!";
+    for (0..20000) |i| result += i * i;
 }
-
-fn function3() []const u8 {
+fn slowFunction(_: std.mem.Allocator) void {
     var result: usize = 0;
-    var i: usize = 0;
-    while (i < 300000) : (i += 1) {
-        const square = i * i;
-        result += square;
-    }
-
-    return "Hello, world!";
+    for (0..300000) |i| result += i * i;
 }
 
-fn fn1(_: std.mem.Allocator) void {
-    _ = function1();
-}
-
-fn fn2(_: std.mem.Allocator) void {
-    _ = function2();
-}
-
-fn fn3(_: std.mem.Allocator) void {
-    _ = function3();
-}
-
-test "bench test basic" {
+test "bench test summary" {
     const stdout = std.io.getStdOut().writer();
     var bench = zbench.Benchmark.init(test_allocator, .{});
     defer bench.deinit();
 
-    try bench.add("fast function", fn1, .{
+    try bench.add("fast function", fastFunction, .{
         .iterations = 10,
     });
 
-    try bench.add("medium fast function", fn2, .{
+    try bench.add("medium fast function", mediumFunction, .{
         .iterations = 10,
     });
 
-    try bench.add("slow function", fn3, .{
+    try bench.add("slow function", slowFunction, .{
         .iterations = 10,
     });
 

--- a/util/color.zig
+++ b/util/color.zig
@@ -23,4 +23,9 @@ pub const Color = enum {
             .none => "",
         };
     }
+
+    // Method to return ANSI escape code for bold text.
+    pub fn bold() []const u8 {
+        return "\x1b[1m";
+    }
 };

--- a/util/color.zig
+++ b/util/color.zig
@@ -8,6 +8,7 @@ pub const Color = enum {
     magenta,
     cyan,
     reset,
+    bold,
     none,
 
     // Return the ANSI escape code for this color.
@@ -20,12 +21,8 @@ pub const Color = enum {
             .magenta => "\x1b[35m",
             .cyan => "\x1b[36m",
             .reset => "\x1b[0m",
+            .bold => "\x1b[1m",
             .none => "",
         };
-    }
-
-    // Method to return ANSI escape code for bold text.
-    pub fn bold() []const u8 {
-        return "\x1b[1m";
     }
 };

--- a/zbench.zig
+++ b/zbench.zig
@@ -158,34 +158,34 @@ pub const Results = struct {
     pub fn printSummary(self: Results, writer: anytype) !void {
         if (self.results.len == 0) return;
 
-        const bold = Color.bold.code();
-        const resetCode = Color.reset.code();
-        const greenCode = Color.green.code();
-        const blueCode = Color.blue.code();
+        const bold_code = Color.bold.code();
+        const reset_code = Color.reset.code();
+        const green_code = Color.green.code();
+        const blue_code = Color.blue.code();
 
         // Find the fastest result without sorting
-        var fastestIndex: usize = 0;
-        var fastestTime = self.results[0].statistics.mean_ns;
+        var fastest_index: usize = 0;
+        var fastest_time = self.results[0].statistics.mean_ns;
         for (self.results, 0..) |res, i| {
-            if (res.statistics.mean_ns < fastestTime) {
-                fastestTime = res.statistics.mean_ns;
-                fastestIndex = i;
+            if (res.statistics.mean_ns < fastest_time) {
+                fastest_time = res.statistics.mean_ns;
+                fastest_index = i;
             }
         }
 
         // Print Summary Heading in Bold
-        try writer.print("\n \n{s}Summary{s}\n", .{ bold, resetCode });
+        try writer.print("\n \n{s}Summary{s}\n", .{ bold_code, reset_code });
 
-        try writer.print("{s}", .{greenCode});
-        try writer.print("{s}", .{self.results[fastestIndex].name});
-        try writer.print("{s} ran\n", .{resetCode});
+        try writer.print("{s}", .{green_code});
+        try writer.print("{s}", .{self.results[fastest_index].name});
+        try writer.print("{s} ran\n", .{reset_code});
 
         for (self.results, 0..) |res, i| {
-            if (i == fastestIndex) continue; // Skip the fastest since it's already printed
-            const times = @as(f64, @floatFromInt(res.statistics.mean_ns)) / @as(f64, @floatFromInt(fastestTime));
+            if (i == fastest_index) continue; // Skip the fastest since it's already printed
+            const times = @as(f64, @floatFromInt(res.statistics.mean_ns)) / @as(f64, @floatFromInt(fastest_time));
 
-            try writer.print(" └─ {s}{d:.2}x times{s} faster than {s}{s}\n", .{ greenCode, times, resetCode, blueCode, res.name });
-            try writer.print("{s}", .{resetCode});
+            try writer.print(" └─ {s}{d:.2}x times{s} faster than {s}{s}\n", .{ green_code, times, reset_code, blue_code, res.name });
+            try writer.print("{s}", .{reset_code});
         }
     }
 

--- a/zbench.zig
+++ b/zbench.zig
@@ -152,6 +152,9 @@ pub const Results = struct {
         for (self.results) |r| try r.prettyPrint(writer, colors);
     }
 
+    /// Prints a summary output at the end of benchmarking sessions
+    /// This summary highlights the fastest benchmark by name in green, and compares each
+    /// subsequent benchmark to show how many times slower they are relative to the fastest.
     pub fn printSummary(self: Results, writer: anytype) !void {
         if (self.results.len == 0) return;
 

--- a/zbench.zig
+++ b/zbench.zig
@@ -300,11 +300,6 @@ pub const Results = struct {
     pub fn printSummary(self: Results, writer: anytype) !void {
         if (self.results.len == 0) return;
 
-        const bold_code = Color.bold.code();
-        const reset_code = Color.reset.code();
-        const green_code = Color.green.code();
-        const blue_code = Color.blue.code();
-
         // Find the fastest result without sorting
         var fastest_index: usize = 0;
         var fastest_time = self.results[0].statistics.mean_ns;
@@ -316,18 +311,18 @@ pub const Results = struct {
         }
 
         // Print Summary Heading in Bold
-        try writer.print("\n \n{s}Summary{s}\n", .{ bold_code, reset_code });
+        try writer.print("\n \n{s}Summary{s}\n", .{ Color.bold.code(), Color.reset.code() });
 
-        try writer.print("{s}", .{green_code});
+        try writer.print("{s}", .{Color.green.code()});
         try writer.print("{s}", .{self.results[fastest_index].name});
-        try writer.print("{s} ran\n", .{reset_code});
+        try writer.print("{s} ran\n", .{Color.reset.code()});
 
         for (self.results, 0..) |res, i| {
             if (i == fastest_index) continue; // Skip the fastest since it's already printed
             const times = @as(f64, @floatFromInt(res.statistics.mean_ns)) / @as(f64, @floatFromInt(fastest_time));
 
-            try writer.print(" └─ {s}{d:.2}x times{s} faster than {s}{s}\n", .{ green_code, times, reset_code, blue_code, res.name });
-            try writer.print("{s}", .{reset_code});
+            try writer.print(" └─ {s}{d:.2}x times{s} faster than {s}{s}\n", .{ Color.green.code(), times, Color.reset.code(), Color.blue.code(), res.name });
+            try writer.print("{s}", .{Color.reset.code()});
         }
     }
 

--- a/zbench.zig
+++ b/zbench.zig
@@ -158,7 +158,7 @@ pub const Results = struct {
     pub fn printSummary(self: Results, writer: anytype) !void {
         if (self.results.len == 0) return;
 
-        const bold = Color.bold();
+        const bold = Color.bold.code();
         const resetCode = Color.reset.code();
         const greenCode = Color.green.code();
         const blueCode = Color.blue.code();


### PR DESCRIPTION
Implement a new feature in the benchmark module to display a summary at the end of benchmarking output. This summary includes the fastest benchmark, and a comparison of each benchmark showing how many times slower they are relative to the fastest. This enhancement aims to provide users with a quick overview of their code's performance characteristics.

<img width="666" alt="Bildschirmfoto 2024-03-17 um 22 20 34" src="https://github.com/hendriknielaender/zBench/assets/51416554/969dd4f0-6959-4643-b791-16d8546d7504">


close https://github.com/hendriknielaender/zBench/issues/64