### PR TITLE
Add memory allocation tracking

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -63,6 +63,7 @@ fn setupExamples(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
         "bubble_sort",
         "hooks",
         "json",
+        "memory_tracking",
         "parameterised",
         "progress",
         "sleep",

--- a/examples/json.zig
+++ b/examples/json.zig
@@ -17,7 +17,14 @@ test "bench test json" {
     var bench = zbench.Benchmark.init(test_allocator, .{});
     defer bench.deinit();
 
-    try bench.add("My Benchmark 1", myBenchmark, .{ .iterations = 10 });
+    try bench.add("My Benchmark 1", myBenchmark, .{
+        .iterations = 10,
+        .track_allocations = false,
+    });
+    try bench.add("My Benchmark 2", myBenchmark, .{
+        .iterations = 10,
+        .track_allocations = true,
+    });
 
     try stdout.writeAll("[");
     var iter = try bench.iterator();

--- a/examples/memory_tracking.zig
+++ b/examples/memory_tracking.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const zbench = @import("zbench");
+
+fn myBenchmark(allocator: std.mem.Allocator) void {
+    for (0..2000) |_| {
+        const buf = allocator.alloc(u8, 512) catch @panic("OOM");
+        defer allocator.free(buf);
+    }
+}
+
+test "bench test basic" {
+    const stdout = std.io.getStdOut().writer();
+    var bench = zbench.Benchmark.init(std.testing.allocator, .{
+        .iterations = 64,
+    });
+    defer bench.deinit();
+
+    try bench.add("My Benchmark 1", myBenchmark, .{});
+    try bench.add("My Benchmark 2", myBenchmark, .{
+        .track_allocations = true,
+    });
+
+    try stdout.writeAll("\n");
+    try bench.run(stdout);
+}

--- a/util/runner/types.zig
+++ b/util/runner/types.zig
@@ -6,14 +6,86 @@ pub const Step = enum { more };
 
 pub const Reading = struct {
     timing_ns: u64,
+    allocation: ?AllocationReading,
 
-    pub fn init(timing_ns: u64) Reading {
+    pub fn init(
+        timing_ns: u64,
+        allocation: ?AllocationReading,
+    ) Reading {
         return .{
             .timing_ns = timing_ns,
+            .allocation = allocation,
         };
     }
 };
 
 pub const Readings = struct {
+    allocator: std.mem.Allocator,
+    iterations: usize,
     timings_ns: []u64,
+    allocations: ?AllocationReadings,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        n: usize,
+        track_allocations: bool,
+    ) !Readings {
+        return Readings{
+            .allocator = allocator,
+            .iterations = n,
+            .timings_ns = try allocator.alloc(u64, n),
+            .allocations = if (track_allocations)
+                try AllocationReadings.init(allocator, n)
+            else
+                null,
+        };
+    }
+
+    pub fn deinit(self: Readings) void {
+        self.allocator.free(self.timings_ns);
+        if (self.allocations) |allocs| allocs.deinit(self.allocator);
+    }
+
+    pub fn set(self: *Readings, i: usize, reading: Reading) void {
+        self.timings_ns[i] = reading.timing_ns;
+        if (self.allocations) |allocs| {
+            if (reading.allocation) |x| {
+                allocs.maxes[i] = x.max;
+                allocs.counts[i] = x.count;
+            } else {
+                allocs.deinit(self.allocator);
+                self.allocations = null;
+            }
+        }
+    }
+
+    pub fn sort(self: *Readings) void {
+        std.sort.heap(u64, self.timings_ns, {}, std.sort.asc(u64));
+        if (self.allocations) |allocs| {
+            std.sort.heap(usize, allocs.maxes, {}, std.sort.asc(usize));
+            std.sort.heap(usize, allocs.counts, {}, std.sort.asc(usize));
+        }
+    }
+};
+
+pub const AllocationReading = struct {
+    max: usize,
+    count: usize,
+};
+
+pub const AllocationReadings = struct {
+    maxes: []usize,
+    counts: []usize,
+
+    pub fn init(allocator: std.mem.Allocator, n: usize) !AllocationReadings {
+        return AllocationReadings{
+            .maxes = try allocator.alloc(usize, n),
+            .counts = try allocator.alloc(usize, n),
+        };
+    }
+
+    pub fn deinit(self: AllocationReadings, allocator: std.mem.Allocator) void {
+        allocator.free(self.maxes);
+        allocator.free(self.counts);
+    }
 };

--- a/util/statistics.zig
+++ b/util/statistics.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+/// Collect common statistical calculations together.
 pub fn Statistics(comptime T: type) type {
     return struct {
         total: T,

--- a/util/tracking_allocator.zig
+++ b/util/tracking_allocator.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const TrackingAllocator = @This();
+
+parent_allocator: Allocator,
+current_allocated: usize = 0,
+max_allocated: usize = 0,
+allocation_count: usize = 0,
+
+pub fn init(parent_allocator: Allocator) TrackingAllocator {
+    return .{
+        .parent_allocator = parent_allocator,
+    };
+}
+
+pub fn allocator(self: *TrackingAllocator) Allocator {
+    return .{
+        .ptr = self,
+        .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .free = free,
+        },
+    };
+}
+
+pub fn maxAllocated(self: TrackingAllocator) usize {
+    return self.max_allocated;
+}
+
+pub fn allocationCount(self: TrackingAllocator) usize {
+    return self.allocation_count;
+}
+
+fn alloc(
+    ctx: *anyopaque,
+    len: usize,
+    log2_ptr_align: u8,
+    ra: usize,
+) ?[*]u8 {
+    const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+    const result = self.parent_allocator.rawAlloc(len, log2_ptr_align, ra);
+    if (result) |_| {
+        self.allocation_count += 1;
+        self.current_allocated += len;
+        if (self.max_allocated < self.current_allocated)
+            self.max_allocated = self.current_allocated;
+    }
+    return result;
+}
+
+fn resize(
+    ctx: *anyopaque,
+    buf: []u8,
+    log2_buf_align: u8,
+    new_len: usize,
+    ra: usize,
+) bool {
+    const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+    const result = self.parent_allocator.rawResize(buf, log2_buf_align, new_len, ra);
+    if (result) {
+        self.allocation_count += 1;
+        if (buf.len < new_len) {
+            self.current_allocated += new_len - buf.len;
+            if (self.max_allocated < self.current_allocated)
+                self.max_allocated = self.current_allocated;
+        } else self.current_allocated -= buf.len - new_len;
+    }
+    return result;
+}
+
+fn free(
+    ctx: *anyopaque,
+    buf: []u8,
+    log2_buf_align: u8,
+    ra: usize,
+) void {
+    const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+    self.parent_allocator.rawFree(buf, log2_buf_align, ra);
+    self.current_allocated -= buf.len;
+}
+
+/// This allocator is used in front of another allocator and tracks the maximum
+/// memory usage on every call to the allocator.
+pub fn trackingAllocator(parent_allocator: Allocator) TrackingAllocator {
+    return TrackingAllocator.init(parent_allocator);
+}


### PR DESCRIPTION
Adds a custom `Allocator` wrapper which keeps track of the allocated memory, then record the maximum allocation readings in the `Runner` alongside timing readings and carry them into the `Result`. I've added equivalent statistics for memory use as for timings, but maybe we only need something simpler?

Current output:
```
benchmark              runs     total time     time/run (avg ± σ)     (min ... max)                p75        p99        p995
-----------------------------------------------------------------------------------------------------------------------------
My Benchmark           10       1.118ms        111.879us ± 14.24us    (98.058us ... 136.68us)      125.995us  136.68us   136.68us
My Benchmark [MEMORY]                          2.000KiB ± 0B          (2.000KiB ... 2.000KiB)      2KiB       2KiB       2KiB
```