### PR TITLE
Remove std.Progress

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -1,12 +1,14 @@
 const std = @import("std");
 const zbench = @import("zbench");
 
-fn myBenchmark(_: std.mem.Allocator) void {
+fn myBenchmark(allocator: std.mem.Allocator) void {
     var result: usize = 0;
     for (0..1_000_000) |i| {
         std.mem.doNotOptimizeAway(i);
         result += i * i;
     }
+    const buf = allocator.alloc(u8, 512) catch @panic("OOM");
+    defer allocator.free(buf);
 }
 
 test "bench test basic" {

--- a/zbench.zig
+++ b/zbench.zig
@@ -220,25 +220,12 @@ pub const Benchmark = struct {
 
     /// Run all benchmarks and collect timing information.
     pub fn run(self: Benchmark, writer: anytype) !void {
-        var progress = std.Progress{};
-        const progress_node = progress.start("", 0);
-        defer progress_node.end();
-
         try self.prettyPrintHeader(writer);
         var iter = try self.iterator();
         while (try iter.next()) |step| switch (step) {
-            .progress => |p| {
-                progress_node.setEstimatedTotalItems(p.total_runs);
-                progress_node.setCompletedItems(p.completed_runs);
-                progress_node.setName(p.current_name);
-                progress.maybeRefresh();
-            },
+            .progress => |_| {},
             .result => |x| {
                 defer x.deinit();
-                progress_node.setName("");
-                progress_node.setEstimatedTotalItems(0);
-                progress_node.setCompletedItems(0);
-                progress.refresh();
                 try x.prettyPrint(writer, true);
             },
         };


### PR DESCRIPTION
It seems to have been scribbling over the allocator in `Benchmarks`, resulting in segfaults, I couldn't pin down exactly how it was doing it but either removing the `setName()` and `maybeRefresh()` calls or removing it altogether worked to eliminate the segfaults. Further investigation needed before adding it back in.