### PR TITLE
Add std.Progress back in

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -2,13 +2,10 @@ const std = @import("std");
 const zbench = @import("zbench");
 
 fn myBenchmark(allocator: std.mem.Allocator) void {
-    var result: usize = 0;
-    for (0..1_000_000) |i| {
-        std.mem.doNotOptimizeAway(i);
-        result += i * i;
+    for (0..1000) |_| {
+        const buf = allocator.alloc(u8, 512) catch @panic("Out of memory");
+        defer allocator.free(buf);
     }
-    const buf = allocator.alloc(u8, 512) catch @panic("OOM");
-    defer allocator.free(buf);
 }
 
 test "bench test basic" {


### PR DESCRIPTION
The issue wasn't with `std.Progress` at all, I was passing a pointer into the stack which escaped the stack lifetime in the `Benchmark.iterator()` method, so definitely my fault.