### PR TITLE
Don't mutate the readings when calculating statistics

### DIFF
--- a/examples/json.zig
+++ b/examples/json.zig
@@ -35,7 +35,7 @@ test "bench test json" {
             defer x.deinit();
             defer i += 1;
             if (0 < i) try stdout.writeAll(", ");
-            try x.writeJSON(stdout);
+            try x.writeJSON(test_allocator, stdout);
         },
     };
     try stdout.writeAll("]\n");

--- a/examples/memory_tracking.zig
+++ b/examples/memory_tracking.zig
@@ -8,7 +8,7 @@ fn myBenchmark(allocator: std.mem.Allocator) void {
     }
 }
 
-test "bench test basic" {
+test "bench test memory tracking" {
     const stdout = std.io.getStdOut().writer();
     var bench = zbench.Benchmark.init(std.testing.allocator, .{
         .iterations = 64,

--- a/examples/progress.zig
+++ b/examples/progress.zig
@@ -46,7 +46,7 @@ test "bench test progress" {
             progress_node.setEstimatedTotalItems(0);
             progress_node.setCompletedItems(0);
             progress.refresh();
-            try x.prettyPrint(stdout, true);
+            try x.prettyPrint(test_allocator, stdout, true);
         },
     };
 }

--- a/util/runner/types.zig
+++ b/util/runner/types.zig
@@ -58,14 +58,6 @@ pub const Readings = struct {
             }
         }
     }
-
-    pub fn sort(self: *Readings) void {
-        std.sort.heap(u64, self.timings_ns, {}, std.sort.asc(u64));
-        if (self.allocations) |allocs| {
-            std.sort.heap(usize, allocs.maxes, {}, std.sort.asc(usize));
-            std.sort.heap(usize, allocs.counts, {}, std.sort.asc(usize));
-        }
-    }
 };
 
 pub const AllocationReading = struct {

--- a/zbench.zig
+++ b/zbench.zig
@@ -234,7 +234,6 @@ pub const Benchmark = struct {
                 defer self.remaining = self.remaining[1..];
                 if (self.remaining[0].config.hooks.after_all) |hook| hook();
                 return Step{ .result = try Result.init(
-                    self.allocator,
                     self.remaining[0].name,
                     try runner.finish(),
                 ) };
@@ -267,6 +266,11 @@ pub const Benchmark = struct {
         const progress_node = progress.start("", 0);
         defer progress_node.end();
 
+        // Most allocations for pretty printing will be the same size each time,
+        // so using an arena should reduce the allocation load.
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena.deinit();
+
         try prettyPrintHeader(writer);
         var iter = try self.iterator();
         while (try iter.next()) |step| switch (step) {
@@ -282,7 +286,8 @@ pub const Benchmark = struct {
                 progress_node.setEstimatedTotalItems(0);
                 progress_node.setCompletedItems(0);
                 progress.refresh();
-                try x.prettyPrint(writer, true);
+                try x.prettyPrint(arena.allocator(), writer, true);
+                _ = arena.reset(.retain_capacity);
             },
         };
     }
@@ -316,20 +321,11 @@ pub fn getSystemInfo() !platform.OsInfo {
 /// durations are available, and some basic statistics are automatically
 /// calculated.
 pub const Result = struct {
-    allocator: std.mem.Allocator,
     name: []const u8,
     readings: Readings,
 
-    pub fn init(
-        allocator: std.mem.Allocator,
-        name: []const u8,
-        readings: Runner.Readings,
-    ) !Result {
-        return Result{
-            .allocator = allocator,
-            .name = name,
-            .readings = readings,
-        };
+    pub fn init(name: []const u8, readings: Runner.Readings) !Result {
+        return Result{ .name = name, .readings = readings };
     }
 
     pub fn deinit(self: Result) void {
@@ -339,11 +335,16 @@ pub const Result = struct {
     /// Formats and prints the benchmark result in a human readable format.
     /// writer: Type that has the associated method print (for example std.io.getStdOut.writer())
     /// colors: Whether to pretty-print with ANSI colors or not.
-    pub fn prettyPrint(self: Result, writer: anytype, colors: bool) !void {
+    pub fn prettyPrint(
+        self: Result,
+        allocator: std.mem.Allocator,
+        writer: anytype,
+        colors: bool,
+    ) !void {
         var buf: [128]u8 = undefined;
 
         const timings_ns = self.readings.timings_ns;
-        const s = try Statistics(u64).init(self.allocator, timings_ns);
+        const s = try Statistics(u64).init(allocator, timings_ns);
         // Benchmark name, number of iterations, and total time
         try writer.print("{s:<22} ", .{self.name});
         try setColor(colors, writer, Color.cyan);
@@ -379,7 +380,7 @@ pub const Result = struct {
         try writer.writeAll("\n");
 
         if (self.readings.allocations) |allocs| {
-            const m = try Statistics(usize).init(self.allocator, allocs.maxes);
+            const m = try Statistics(usize).init(allocator, allocs.maxes);
             // Benchmark name
             const name = try std.fmt.bufPrint(&buf, "{s} [MEMORY]", .{
                 self.name,
@@ -418,12 +419,16 @@ pub const Result = struct {
         if (colors) try writer.writeAll(color.code());
     }
 
-    pub fn writeJSON(self: Result, writer: anytype) !void {
+    pub fn writeJSON(
+        self: Result,
+        allocator: std.mem.Allocator,
+        writer: anytype,
+    ) !void {
         const timings_ns_stats =
-            try Statistics(u64).init(self.allocator, self.readings.timings_ns);
+            try Statistics(u64).init(allocator, self.readings.timings_ns);
         if (self.readings.allocations) |allocs| {
             const allocation_maxes_stats =
-                try Statistics(usize).init(self.allocator, allocs.maxes);
+                try Statistics(usize).init(allocator, allocs.maxes);
             try writer.print(
                 \\{{ "name": "{s}",
                 \\   "timing_statistics": {}, "timings": {},


### PR DESCRIPTION
There isn't much cost to making a temporary copy of them for sorting, IMHO, and it preserves the link between the readings for each run. It makes the code simpler too in that `Statistics.init` doesn't need to be called with sorted readings now.