### PR TITLE
feat(benchmark): add summary output for benchmark comparisons

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -66,6 +66,7 @@ fn setupExamples(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
         "memory_tracking",
         "parameterised",
         "progress",
+        "summary",
         "sleep",
         "systeminfo",
     };

--- a/examples/summary.zig
+++ b/examples/summary.zig
@@ -23,6 +23,13 @@ fn slowFunction(_: std.mem.Allocator) void {
         result += i * i;
     }
 }
+fn slowestFunction(_: std.mem.Allocator) void {
+    var result: usize = 0;
+    for (0..1_000_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
+}
 
 test "empty bench test summary" {
     const stdout = std.io.getStdOut().writer();
@@ -62,6 +69,10 @@ test "bench test summary" {
     });
 
     try bench.add("slow function", slowFunction, .{
+        .iterations = 10,
+    });
+
+    try bench.add("slowest function", slowestFunction, .{
         .iterations = 10,
     });
 

--- a/examples/summary.zig
+++ b/examples/summary.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const zbench = @import("zbench");
+const test_allocator = std.testing.allocator;
+
+fn fastFunction(_: std.mem.Allocator) void {
+    var result: usize = 0;
+    for (0..1_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
+}
+fn mediumFunction(_: std.mem.Allocator) void {
+    var result: usize = 0;
+    for (0..20_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
+}
+fn slowFunction(_: std.mem.Allocator) void {
+    var result: usize = 0;
+    for (0..300_000) |i| {
+        std.mem.doNotOptimizeAway(i);
+        result += i * i;
+    }
+}
+
+test "bench test summary" {
+    const stdout = std.io.getStdOut().writer();
+    var bench = zbench.Benchmark.init(std.testing.allocator, .{
+        .display_summary = true,
+    });
+    defer bench.deinit();
+
+    try bench.add("fast function", fastFunction, .{
+        .iterations = 10,
+    });
+
+    try bench.add("medium fast function", mediumFunction, .{
+        .iterations = 10,
+    });
+
+    try bench.add("slow function", slowFunction, .{
+        .iterations = 10,
+    });
+
+    try stdout.writeAll("\n");
+    try bench.run(stdout);
+}

--- a/examples/summary.zig
+++ b/examples/summary.zig
@@ -24,6 +24,28 @@ fn slowFunction(_: std.mem.Allocator) void {
     }
 }
 
+test "empty bench test summary" {
+    const stdout = std.io.getStdOut().writer();
+    var bench = zbench.Benchmark.init(std.testing.allocator, .{ .display_summary = true });
+    defer bench.deinit();
+    // No benchmarks added
+
+    try stdout.writeAll("No Benchmarks Added:\n");
+    try bench.run(stdout);
+}
+
+test "single bench test summary" {
+    const stdout = std.io.getStdOut().writer();
+    var bench = zbench.Benchmark.init(std.testing.allocator, .{ .display_summary = true });
+    defer bench.deinit();
+
+    // Single benchmark
+    try bench.add("fast function", fastFunction, .{ .iterations = 10 });
+
+    try stdout.writeAll("Single Benchmark Added:\n");
+    try bench.run(stdout);
+}
+
 test "bench test summary" {
     const stdout = std.io.getStdOut().writer();
     var bench = zbench.Benchmark.init(std.testing.allocator, .{
@@ -31,11 +53,11 @@ test "bench test summary" {
     });
     defer bench.deinit();
 
-    try bench.add("fast function", fastFunction, .{
+    try bench.add("medium fast function", mediumFunction, .{
         .iterations = 10,
     });
 
-    try bench.add("medium fast function", mediumFunction, .{
+    try bench.add("fast function", fastFunction, .{
         .iterations = 10,
     });
 

--- a/zbench.zig
+++ b/zbench.zig
@@ -328,6 +328,7 @@ pub const Benchmark = struct {
     }
 };
 
+/// Prints a comparative summary of benchmark results if more than one benchmark exists.
 fn printSummary(writer: anytype, results: []const Result, fastest_ns: u64, fastest_name: []const u8) !void {
     // Check if there is more than one benchmark
     if (results.len <= 1) return;

--- a/zbench.zig
+++ b/zbench.zig
@@ -335,19 +335,21 @@ fn printSummary(writer: anytype, results: []const Result, fastest_ns: u64, faste
     try writer.print("\x1b[1mSummary:\x1b[0m\n", .{});
     try writer.print("{s} ran\n", .{fastest_name});
 
-    var last_index = results.len - 1;
-    for (results, 0..) |result, index| {
-        // Skip the fastest since it is being used as the baseline
-        if (std.mem.eql(u8, result.name, fastest_name)) continue;
+    var j: usize = 0; // Counter for non-fastest benchmarks.
+    for (results) |result| {
+        if (std.mem.eql(u8, result.name, fastest_name)) continue; // Skip the fastest.
 
+        // Compute how many times slower each benchmark is relative to the fastest.
         const total_duration_f64 = @as(f64, @floatFromInt(result.total_duration_ns));
         const fastest_duration_f64 = @as(f64, @floatFromInt(fastest_ns));
-
         const times_slower = total_duration_f64 / fastest_duration_f64;
 
-        const connector_char = if (index == last_index) " └─" else " ├─";
+        const is_last_non_fastest = (j == results.len - 2);
+        const connector_char = if (is_last_non_fastest) " └─" else " ├─";
 
-        try writer.print(" {s} {d:.2}x times faster than {s}\n", .{ connector_char, times_slower, result.name });
+        // Print the result comparison.
+        try writer.print("{s} {d:.2}x times faster than {s}\n", .{ connector_char, times_slower, result.name });
+        j += 1; // Increment only for non-fastest items.
     }
 }
 

--- a/zbench.zig
+++ b/zbench.zig
@@ -329,6 +329,9 @@ pub const Benchmark = struct {
 };
 
 fn printSummary(writer: anytype, results: []const Result, fastest_ns: u64, fastest_name: []const u8) !void {
+    // Check if there is more than one benchmark
+    if (results.len <= 1) return;
+
     try writer.print("\x1b[1mSummary:\x1b[0m\n", .{});
     try writer.print("{s} ran\n", .{fastest_name});
 


### PR DESCRIPTION
Implement a new feature in the benchmark module to display a summary at the end of benchmarking output. This summary includes the fastest benchmark, and a comparison of each benchmark showing how many times slower they are relative to the fastest. This enhancement aims to provide users with a quick overview of their code's performance characteristics.

closes #64 