### PR TITLE
use std.Build.path function instead of std.Build.LazyPath.path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -23,7 +23,7 @@ pub fn build(b: *std.Build) void {
 fn setupLibrary(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) *std.Build.Step.Compile {
     const lib = b.addStaticLibrary(.{
         .name = "zbench",
-        .root_source_file = .{ .path = "zbench.zig" },
+        .root_source_file = b.path("zbench.zig"),
         .target = target,
         .optimize = optimize,
         .version = version,
@@ -47,7 +47,7 @@ fn setupTesting(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.b
     for (test_files) |test_file| {
         const _test = b.addTest(.{
             .name = test_file.name,
-            .root_source_file = .{ .path = test_file.path },
+            .root_source_file = b.path(test_file.path),
             .target = target,
             .optimize = optimize,
         });
@@ -73,13 +73,13 @@ fn setupExamples(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
     for (example_names) |example_name| {
         const example = b.addTest(.{
             .name = example_name,
-            .root_source_file = .{ .path = b.fmt("examples/{s}.zig", .{example_name}) },
+            .root_source_file = b.path(b.fmt("examples/{s}.zig", .{example_name})),
             .target = target,
             .optimize = optimize,
         });
         const install_example = b.addInstallArtifact(example, .{});
         const zbench_mod = b.addModule("zbench", .{
-            .root_source_file = .{ .path = "zbench.zig" },
+            .root_source_file = b.path("zbench.zig"),
         });
         example.root_module.addImport("zbench", zbench_mod);
         example_step.dependOn(&example.step);


### PR DESCRIPTION
std.Build.LazyPath.path has been deprecated in Zig 0.12 and will be removed in 0.13. `std.Build.path` works for both 0.12 stable and the current 0.13-dev branch of Zig. This PR is to limit the changes needed for the 0.13 adaption in the future. 