### PR TITLE
chore: improve output lisibility

### DIFF
--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -11,5 +11,6 @@ test "bench test sleepy" {
     var bench = zbench.Benchmark.init(test_allocator, .{});
     defer bench.deinit();
     try bench.add("Sleep Benchmark", sleepBenchmark, .{});
+    try stdout.writeAll("\n");
     try bench.run(stdout);
 }


### PR DESCRIPTION
While running all examples, I noticed that the sleep example output was not very clean. I added a new line to make it properly aligned