### PR TITLE
Support @typeInfo for 0.14.0

### DIFF
--- a/examples/bubble_sort_hooks.zig
+++ b/examples/bubble_sort_hooks.zig
@@ -78,7 +78,7 @@ const BenchmarkData = struct {
     prng: std.Random.DefaultPrng,
 
     pub fn init(self: *BenchmarkData, allocator: std.mem.Allocator, num: usize) !void {
-        self.prng = std.rand.DefaultPrng.init(blk: {
+        self.prng = std.Random.DefaultPrng.init(blk: {
             var seed: u64 = undefined;
             std.posix.getrandom(std.mem.asBytes(&seed)) catch unreachable;
             break :blk seed;

--- a/util/optional.zig
+++ b/util/optional.zig
@@ -3,9 +3,10 @@ const std = @import("std");
 /// Make every field of the struct T nullable.
 pub fn Optional(comptime T: type) type {
     const T_info = switch (@typeInfo(T)) {
-        .Struct => |x| x,
+        .@"struct" => |x| x,
         else => @compileError("Optional only supports struct types for now"),
     };
+
     var fields: [T_info.fields.len]std.builtin.Type.StructField = undefined;
     for (T_info.fields, &fields) |fi, *fo| {
         fo.* = fi;
@@ -14,14 +15,14 @@ pub fn Optional(comptime T: type) type {
     }
     var result = T_info;
     result.fields = &fields;
-    return @Type(.{ .Struct = result });
+    return @Type(.{ .@"struct" = result });
 }
 
 /// Take any non-null fields from x, and any null fields are taken from y
 /// instead.
 pub fn optional(comptime T: type, x: Optional(T), y: T) T {
     const T_info = switch (@typeInfo(T)) {
-        .Struct => |info| info,
+        .@"struct" => |info| info,
         else => @compileError("Optional only supports struct types for now"),
     };
     var t: T = undefined;

--- a/util/optional.zig
+++ b/util/optional.zig
@@ -11,7 +11,7 @@ pub fn Optional(comptime T: type) type {
     for (T_info.fields, &fields) |fi, *fo| {
         fo.* = fi;
         fo.*.type = ?fi.type;
-        fo.*.default_value = &@as(?fi.type, null);
+        fo.*.default_value_ptr = &@as(?fi.type, null);
     }
     var result = T_info;
     result.fields = &fields;

--- a/zbench.zig
+++ b/zbench.zig
@@ -147,9 +147,11 @@ pub const Benchmark = struct {
         benchmark: anytype,
         config: Optional(Config),
     ) !void {
+        const O = @TypeOf(benchmark);
+
         // Check the benchmark parameter is the proper type.
-        const T: type = switch (@typeInfo(@TypeOf(benchmark))) {
-            .Pointer => |ptr| if (ptr.is_const) ptr.child else @compileError(
+        const T: type = switch (@typeInfo(O)) {
+            .pointer => |ptr| if (ptr.is_const) ptr.child else @compileError(
                 "benchmark must be a const ptr to a struct with a 'run' method",
             ),
             else => @compileError(

--- a/zbench.zig
+++ b/zbench.zig
@@ -147,10 +147,8 @@ pub const Benchmark = struct {
         benchmark: anytype,
         config: Optional(Config),
     ) !void {
-        const O = @TypeOf(benchmark);
-
         // Check the benchmark parameter is the proper type.
-        const T: type = switch (@typeInfo(O)) {
+        const T: type = switch (@typeInfo(@TypeOf(benchmark))) {
             .pointer => |ptr| if (ptr.is_const) ptr.child else @compileError(
                 "benchmark must be a const ptr to a struct with a 'run' method",
             ),


### PR DESCRIPTION
The [@typeInfo](https://ziglang.org/documentation/master/#typeInfo) syntax has change for [switch](https://ziglang.org/documentation/master/#toc-Inline-Switch-Prongs) statements. 
