### PR TITLE
chore: update zig 0.13 install guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -84,8 +84,8 @@ On your project root directory make a directory name libs.
 - Then add the module into your `build.zig`
 
 ```zig
-exe.addAnonymousModule("zbench", .{
-    .source_file = .{ .path = "libs/zbench/zbench.zig" },
+exe.root_module.addAnonymousImport("zbench", .{
+    .root_source_file = b.path("libs/zbench/zbench.zig"),
 });
 ```
 


### PR DESCRIPTION
Install guide is outdated. I used Zig 0.13.0 and got following error.
```
/home/kumiko/test_heap/build.zig:41:8: error: no field or member function named 'addAnonymousModule' in 'Build.Step.Compile'
    exe.addAnonymousModule("zbench", .{
    ~~~^~~~~~~~~~~~~~~~~~~
/usr/lib/zig/std/Build/Step/Compile.zig:1:1: note: struct declared here
const builtin = @import("builtin");
^~~~~
```