### PR TITLE
Updated build.zig.zon to final 0.14 format

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "zbench",
+    .name = .zbench,
+    .fingerprint = 0xbb819b3cb80320b0,
     .version = "0.9.2",
     .paths = .{
         "zbench.zig",


### PR DESCRIPTION
Notes: https://ziglang.org/download/0.14.0/release-notes.html#New-Package-Hash-Format

`name` is now a bare Zig identifier
`fingerprint` added (randomly generated by the compiler)