### PR TITLE
Respect Config.max_iterations when it's different than the default

### DIFF
--- a/util/runner.zig
+++ b/util/runner.zig
@@ -101,7 +101,7 @@ pub fn next(self: *Runner, reading: Reading) Error!?Step {
                 var N: usize = @intCast((st.iteration_loops * st.time_budget_ns) / st.elapsed_ns);
                 // check that N doesn't go out of bounds
                 if (N == 0) N = 1;
-                if (N > DEFAULT_MAX_N_ITER) N = DEFAULT_MAX_N_ITER;
+                if (N > st.max_iterations) N = st.max_iterations;
                 // Now run the benchmark with the adjusted N value
                 self.state = .{ .running = .{
                     .iterations_count = N,


### PR DESCRIPTION
I made this patch mostly for myself but maybe you would like it as well.

Essentially when `Config.max_interations` was different than the default, it did not do anything because we always upper bound by the default max iterations (`DEFAULT_MAX_N_ITER`). Possibly this relies on also using `Config.time_budget_ns` - I did not look too hard.