### PR TITLE
adjust `run` to take `File` instead of `*Writer`

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -9,14 +9,12 @@ fn myBenchmark(allocator: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
 
     var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
     defer bench.deinit();
 
     try bench.add("My Benchmark", myBenchmark, .{});
 
-    try writer.writeAll("\n");
-    try bench.run(writer);
+    try bench.run(stdout);
 }

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -20,14 +20,12 @@ fn myBenchmark(_: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
 
     var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
     defer bench.deinit();
 
     try bench.add("Bubble Sort Benchmark", myBenchmark, .{});
 
-    try writer.writeAll("\n");
-    try bench.run(writer);
+    try bench.run(stdout);
 }

--- a/examples/bubble_sort_hooks.zig
+++ b/examples/bubble_sort_hooks.zig
@@ -49,8 +49,7 @@ fn afterAll() void {
 }
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
 
     var bench = zbench.Benchmark.init(gpa.allocator(), .{});
     defer {
@@ -69,8 +68,7 @@ pub fn main() !void {
         },
     });
 
-    try writer.writeAll("\n");
-    try bench.run(writer);
+    try bench.run(stdout);
 }
 
 const BenchmarkData = struct {

--- a/examples/hooks.zig
+++ b/examples/hooks.zig
@@ -18,8 +18,7 @@ fn myBenchmark(_: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
 
     var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
     defer bench.deinit();
@@ -32,6 +31,5 @@ pub fn main() !void {
         },
     });
 
-    try writer.writeAll("\n");
-    try bench.run(writer);
+    try bench.run(stdout);
 }

--- a/examples/memory_comparison.zig
+++ b/examples/memory_comparison.zig
@@ -172,8 +172,10 @@ fn benchmarkStackUsageNew(allocator: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
+
+    var stdout_w = stdout.writerStreaming(&.{});
+    const writer = &stdout_w.interface;
     var bench = zbench.Benchmark.init(gpa.allocator(), .{
         .iterations = 100,
     });
@@ -200,5 +202,5 @@ pub fn main() !void {
     try bench.add("Old Stack Usage (24KB total)", benchmarkStackUsageOld, .{});
     try bench.add("New Stack Usage (128B total)", benchmarkStackUsageNew, .{});
 
-    try bench.run(writer);
+    try bench.run(stdout);
 }

--- a/examples/memory_tracking.zig
+++ b/examples/memory_tracking.zig
@@ -10,8 +10,10 @@ fn myBenchmark(allocator: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
+
+    var stdout_w = stdout.writerStreaming(&.{});
+    const writer = &stdout_w.interface;
 
     var bench = zbench.Benchmark.init(gpa.allocator(), .{
         .iterations = 64,
@@ -28,5 +30,5 @@ pub fn main() !void {
     });
 
     try writer.writeAll("\n");
-    try bench.run(writer);
+    try bench.run(stdout);
 }

--- a/examples/parameterised.zig
+++ b/examples/parameterised.zig
@@ -18,8 +18,7 @@ const MyBenchmark = struct {
 };
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
 
     var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
     defer bench.deinit();
@@ -27,6 +26,5 @@ pub fn main() !void {
     try bench.addParam("My Benchmark 1", &MyBenchmark.init(100_000), .{});
     try bench.addParam("My Benchmark 2", &MyBenchmark.init(200_000), .{});
 
-    try writer.writeAll("\n");
-    try bench.run(writer);
+    try bench.run(stdout);
 }

--- a/examples/progress.zig
+++ b/examples/progress.zig
@@ -19,8 +19,10 @@ fn myBenchmark2(_: std.mem.Allocator) void {
 
 pub fn main() !void {
     const allocator = std.heap.page_allocator;
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
+
+    var stdout_w = stdout.writerStreaming(&.{});
+    const writer = &stdout_w.interface;
 
     var bench = zbench.Benchmark.init(allocator, .{});
     defer bench.deinit();
@@ -32,7 +34,7 @@ pub fn main() !void {
     try zbench.prettyPrintHeader(writer);
 
     // Detect TTY configuration for color output
-    const tty_config = std.Io.tty.Config.detect(std.fs.File.stdout());
+    const tty_config = std.Io.tty.Config.detect(stdout);
 
     // Initialize the std.Progress api
     const progress = std.Progress.start(.{});

--- a/examples/shuffling_allocator.zig
+++ b/examples/shuffling_allocator.zig
@@ -11,8 +11,7 @@ fn myBenchmark(allocator: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
 
     var bench = zbench.Benchmark.init(gpa.allocator(), .{
         .iterations = 64,
@@ -38,6 +37,5 @@ pub fn main() !void {
         .use_shuffling_allocator = true,
     });
 
-    try writer.writeAll("\n");
-    try bench.run(writer);
+    try bench.run(stdout);
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -6,13 +6,11 @@ fn sleepBenchmark(_: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    var stdout = std.fs.File.stdout().writerStreaming(&.{});
-    const writer = &stdout.interface;
+    const stdout = std.fs.File.stdout();
 
     var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
     defer bench.deinit();
     try bench.add("Sleep Benchmark", sleepBenchmark, .{});
 
-    try writer.writeAll("\n");
-    try bench.run(writer);
+    try bench.run(stdout);
 }

--- a/src/zbench.zig
+++ b/src/zbench.zig
@@ -176,16 +176,20 @@ pub const Benchmark = struct {
     }
 
     /// Run all benchmarks and collect timing information.
-    pub fn run(self: Benchmark, writer: *std.Io.Writer) !void {
+    pub fn run(self: Benchmark, file: std.fs.File) !void {
         // Most allocations for pretty printing will be the same size each time,
         // so using an arena should reduce the allocation load.
         var arena = std.heap.ArenaAllocator.init(self.allocator);
         defer arena.deinit();
 
+        var file_writer = file.writerStreaming(&.{});
+        const writer = &file_writer.interface;
+        try writer.writeByte('\n');
+
         try prettyPrintHeader(writer);
 
         // Detect TTY configuration for color output
-        const tty_config = std.Io.tty.Config.detect(std.fs.File.stdout());
+        const tty_config = std.Io.tty.Config.detect(file);
 
         var iter = try self.iterator();
         while (try iter.next()) |step| switch (step) {


### PR DESCRIPTION
change `run` to accept `File` instead of writer, to make sure tty_config is consistent. In case one wants to print to stderr or to a file instead.

The other alternative was to use `@fieldParentPtr` on the passed `writer`, but then there is no guarantee that the pointed to interface comes from a `File`. I thought this is safer overall.

`zig build examples` compiles and runs fine.
