### PR TITLE
fix parametrized benchmarks

### DIFF
--- a/examples/parameterised.zig
+++ b/examples/parameterised.zig
@@ -8,7 +8,7 @@ const MyBenchmark = struct {
         return .{ .loops = loops };
     }
 
-    pub fn run(self: MyBenchmark, _: std.mem.Allocator) void {
+    pub fn run(self: *MyBenchmark, _: std.mem.Allocator) void {
         var result: usize = 0;
         for (0..self.loops) |i| {
             std.mem.doNotOptimizeAway(i);

--- a/zbench.zig
+++ b/zbench.zig
@@ -174,7 +174,7 @@ pub const Benchmark = struct {
         };
 
         // Check the benchmark parameter has a well typed run function.
-        _ = @as(fn (T, std.mem.Allocator) void, T.run);
+        _ = @as(fn (*T, std.mem.Allocator) void, T.run);
 
         try self.benchmarks.append(self.allocator, Definition{
             .name = name,


### PR DESCRIPTION
see https://github.com/hendriknielaender/zBench/issues/131 - if we do not pass the benchmark struct as pointer, the compiler might decide to pass it as pointer anyways which in turn can result in undefined behavior.

@hendriknielaender @bens tbd - should we use a const pointer? *not* using const ptr might be more flexible.

p.s. I thought it might be better to make this change in the zig-0.15.1 branch first, since the main branch requires a couple of other changes as well to work with latest Zig master. Don't want that noise here ;-)