### PR TITLE
fix: progress example

### DIFF
--- a/examples/progress.zig
+++ b/examples/progress.zig
@@ -18,7 +18,10 @@ fn myBenchmark2(_: std.mem.Allocator) void {
 }
 
 pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
+    // std.Progress spawns a redraw worker via `io.concurrent`, so this example
+    // needs a threaded I/O runtime instead of `init_single_threaded`.
+    var threaded = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer threaded.deinit();
     const io = threaded.io();
     const stdout: std.Io.File = .stdout();
 


### PR DESCRIPTION
the progress example now uses `std.Io.Threaded.init(...)` instead of `.init_single_threaded`. On Zig `0.16.0-dev.2973+06b85a4fd`, `std.Progress` relies on `io.concurrent` for its redraw worker, so the old example was effectively disabling progress output.

closes https://github.com/hendriknielaender/zBench/issues/144