### PR TITLE
examples: use init: std.process.Init

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -24,13 +24,11 @@ zBench provides two ways to register hooks: globally or for a given benchmark.
 Global registration adds hooks to each added benchmark.
 
 ```zig
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
-
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(std.heap.page_allocator, .{ .hooks = .{
+    var bench = zbench.Benchmark.init(init.gpa, .{ .hooks = .{
         .before_all = beforeAllHook,
         .after_all = afterAllHook,
     } });
@@ -50,13 +48,11 @@ In this example, both Benchmark 1 and Benchmark 2 will execute `beforeAllHook` a
 Hooks can also be included with the `add` and `addParam` methods. 
 
 ```zig
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
-
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
+    var bench = zbench.Benchmark.init(init.gpa, .{});
     defer bench.deinit();
 
     try bench.add("Benchmark 1", myBenchmark, .{

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,23 +15,25 @@ Declare zbench as a dependency and add it to your `build.zig.zon`. Replace `<COM
 Import zbench in your Zig code and create a benchmark function:
 
 ```zig
+const std = @import("std");
 const zbench = @import("zbench");
 
-fn benchmarkMyFunction(_: *zbench.Benchmark) void {
+fn benchmarkMyFunction(_: std.mem.Allocator) void {
     // Benchmark code here
 }
 ```
 
-Run the benchmark in a test:
+Run the benchmark from main:
 
 ```zig
-pub fn main() !void {
-    const resultsAlloc = std.ArrayList(zbench.BenchmarkResult).init(test_allocator);
-    var bench = try zbench.Benchmark.init("My Benchmark", std.heap.page_allocator);
-    var benchmarkResults = zbench.BenchmarkResults{
-        .results = resultsAlloc,
-    };
-    defer benchmarkResults.results.deinit();
-    try zbench.run(myBenchmark, &bench, &benchmarkResults);
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const stdout: std.Io.File = .stdout();
+
+    var bench = zbench.Benchmark.init(init.gpa, .{});
+    defer bench.deinit();
+
+    try bench.add("My Benchmark", benchmarkMyFunction, .{});
+    try bench.run(io, stdout);
 }
 ```

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -8,12 +8,11 @@ fn myBenchmark(allocator: std.mem.Allocator) void {
     }
 }
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
+    var bench = zbench.Benchmark.init(init.gpa, .{});
     defer bench.deinit();
 
     try bench.add("My Benchmark", myBenchmark, .{});

--- a/examples/bubble_sort.zig
+++ b/examples/bubble_sort.zig
@@ -19,12 +19,11 @@ fn myBenchmark(_: std.mem.Allocator) void {
     _ = bubbleSort(&numbers);
 }
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
+    var bench = zbench.Benchmark.init(init.gpa, .{});
     defer bench.deinit();
 
     try bench.add("Bubble Sort Benchmark", myBenchmark, .{});

--- a/examples/bubble_sort_hooks.zig
+++ b/examples/bubble_sort_hooks.zig
@@ -10,14 +10,14 @@ const inc = @import("include");
 const zbench = @import("zbench");
 
 // Global variables modified/accessed by the hooks.
-var gpa = std.heap.DebugAllocator(.{}){};
+var benchmark_allocator: std.mem.Allocator = undefined;
 const array_size: usize = 100;
 // BenchmarkData contains the data generation logic.
 var benchmark_data: BenchmarkData = undefined;
 
 // Hooks do not accept any parameters and cannot return anything.
 fn beforeAll() void {
-    benchmark_data.init(gpa.allocator(), array_size) catch unreachable;
+    benchmark_data.init(benchmark_allocator, array_size) catch unreachable;
 }
 
 fn beforeEach() void {
@@ -45,7 +45,7 @@ fn afterEach() void {
 }
 
 fn afterAll() void {
-    benchmark_data.deinit(gpa.allocator());
+    benchmark_data.deinit(benchmark_allocator);
 }
 
 const BenchmarkData = struct {
@@ -74,17 +74,13 @@ const BenchmarkData = struct {
     }
 };
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
+    benchmark_allocator = init.gpa;
 
-    var bench = zbench.Benchmark.init(gpa.allocator(), .{});
-    defer {
-        bench.deinit();
-        const deinit_status = gpa.deinit();
-        if (deinit_status == .leak) std.debug.panic("Memory leak detected", .{});
-    }
+    var bench = zbench.Benchmark.init(init.gpa, .{});
+    defer bench.deinit();
 
     try bench.add("Bubble Sort Benchmark", myBenchmark, .{
         .track_allocations = true, // Option used to show that hooks are not included in the tracking.

--- a/examples/hooks.zig
+++ b/examples/hooks.zig
@@ -17,12 +17,11 @@ fn myBenchmark(_: std.mem.Allocator) void {
     }
 }
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
+    var bench = zbench.Benchmark.init(init.gpa, .{});
     defer bench.deinit();
 
     try bench.add("My Benchmark", myBenchmark, .{

--- a/examples/json.zig
+++ b/examples/json.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const zbench = @import("zbench");
-var gpa = std.heap.DebugAllocator(.{}){};
 
 fn myBenchmark(alloc: std.mem.Allocator) void {
     var result: usize = 0;
@@ -12,19 +11,14 @@ fn myBenchmark(alloc: std.mem.Allocator) void {
     }
 }
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
     var filewriter: std.Io.File.Writer = stdout.writerStreaming(io, &.{});
     const writer: *std.Io.Writer = &filewriter.interface;
 
-    var bench = zbench.Benchmark.init(gpa.allocator(), .{});
-    defer {
-        bench.deinit();
-        const deinit_status = gpa.deinit();
-        if (deinit_status == .leak) std.debug.panic("Memory leak detected", .{});
-    }
+    var bench = zbench.Benchmark.init(init.gpa, .{});
+    defer bench.deinit();
 
     try bench.add("My Benchmark 1", myBenchmark, .{
         .iterations = 10,

--- a/examples/memory_comparison.zig
+++ b/examples/memory_comparison.zig
@@ -3,8 +3,6 @@ const zbench = @import("zbench");
 const builtin = @import("builtin");
 const c = std.c;
 
-var gpa = std.heap.DebugAllocator(.{}){};
-
 const OldSystemInfoBenchmark = struct {
     io: std.Io,
 
@@ -188,21 +186,16 @@ fn benchmarkStackUsageNew(allocator: std.mem.Allocator) void {
     std.mem.doNotOptimizeAway(&scratch);
 }
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
     var filewriter: std.Io.File.Writer = stdout.writerStreaming(io, &.{});
     const writer: *std.Io.Writer = &filewriter.interface;
 
-    var bench = zbench.Benchmark.init(gpa.allocator(), .{
+    var bench = zbench.Benchmark.init(init.gpa, .{
         .iterations = 100,
     });
-    defer {
-        bench.deinit();
-        const deinit_status = gpa.deinit();
-        if (deinit_status == .leak) std.debug.panic("Memory leak detected", .{});
-    }
+    defer bench.deinit();
 
     try writer.writeAll("Memory Usage Comparison: System Info Retrieval\n");
     try writer.writeAll("==============================================\n\n");

--- a/examples/memory_tracking.zig
+++ b/examples/memory_tracking.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const zbench = @import("zbench");
-var gpa = std.heap.DebugAllocator(.{}){};
 
 // amount of memory that should appear in the [MEMORY] section of the output
 const NUM_BYTES = 1024;
@@ -12,19 +11,14 @@ fn myBenchmark(allocator: std.mem.Allocator) void {
     }
 }
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(gpa.allocator(), .{
+    var bench = zbench.Benchmark.init(init.gpa, .{
         .iterations = 64,
     });
-    defer {
-        bench.deinit();
-        const deinit_status = gpa.deinit();
-        if (deinit_status == .leak) std.debug.panic("Memory leak detected", .{});
-    }
+    defer bench.deinit();
 
     try bench.add("My Benchmark 1", myBenchmark, .{});
     try bench.add("My Benchmark 2", myBenchmark, .{ .track_allocations = true });

--- a/examples/parameterised.zig
+++ b/examples/parameterised.zig
@@ -17,12 +17,11 @@ const MyBenchmark = struct {
     }
 };
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
+    var bench = zbench.Benchmark.init(init.gpa, .{});
     defer bench.deinit();
 
     try bench.addParam("My Benchmark 1", &MyBenchmark.init(100_000), .{});

--- a/examples/progress.zig
+++ b/examples/progress.zig
@@ -17,12 +17,11 @@ fn myBenchmark2(_: std.mem.Allocator) void {
     }
 }
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
+    var bench = zbench.Benchmark.init(init.gpa, .{});
     defer bench.deinit();
 
     try bench.add("My Benchmark 1", myBenchmark1, .{});

--- a/examples/shuffling_allocator.zig
+++ b/examples/shuffling_allocator.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const zbench = @import("zbench");
 
-var gpa = std.heap.DebugAllocator(.{}){};
-
 fn myBenchmark(allocator: std.mem.Allocator) void {
     for (0..2000) |_| {
         const buf = allocator.alloc(u8, 512) catch @panic("OOM");
@@ -10,17 +8,12 @@ fn myBenchmark(allocator: std.mem.Allocator) void {
     }
 }
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
 
-    var bench = zbench.Benchmark.init(gpa.allocator(), .{ .iterations = 64 });
-    defer {
-        bench.deinit();
-        const deinit_status = gpa.deinit();
-        if (deinit_status == .leak) std.debug.panic("Memory leak detected", .{});
-    }
+    var bench = zbench.Benchmark.init(init.gpa, .{ .iterations = 64 });
+    defer bench.deinit();
 
     try bench.add("My Benchmark 1", myBenchmark, .{});
     try bench.add("My Benchmark 2 (tracking)", myBenchmark, .{

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -2,22 +2,24 @@ const std = @import("std");
 const zbench = @import("zbench");
 const log = std.log.scoped(.zbench_example_sleep);
 
-// using a global io here so we can use it in the benchmarked function implicitly
-var threaded: std.Io.Threaded = .init_single_threaded;
-const io = threaded.io();
+const SleepBenchmark = struct {
+    io: std.Io,
 
-fn sleepBenchmark(_: std.mem.Allocator) void {
-    io.sleep(.fromMilliseconds(100), .awake) catch |err| {
-        log.err("sleep failed: {}", .{err});
-    };
-}
+    pub fn run(self: *SleepBenchmark, _: std.mem.Allocator) void {
+        self.io.sleep(.fromMilliseconds(100), .awake) catch |err| {
+            log.err("sleep failed: {}", .{err});
+        };
+    }
+};
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const stdout: std.Io.File = .stdout();
+    const sleep_benchmark = SleepBenchmark{ .io = io };
 
-    var bench = zbench.Benchmark.init(std.heap.page_allocator, .{});
+    var bench = zbench.Benchmark.init(init.gpa, .{});
     defer bench.deinit();
 
-    try bench.add("Sleep Benchmark", sleepBenchmark, .{});
+    try bench.addParam("Sleep Benchmark", &sleep_benchmark, .{});
     try bench.run(io, stdout);
 }

--- a/examples/systeminfo.zig
+++ b/examples/systeminfo.zig
@@ -3,8 +3,9 @@ const zbench = @import("zbench");
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
-    var stdout: std.Io.File.Writer = std.Io.File.stdout().writerStreaming(io, &.{});
-    const writer = &stdout.interface;
+    const stdout: std.Io.File = .stdout();
+    var filewriter: std.Io.File.Writer = stdout.writerStreaming(io, &.{});
+    const writer: *std.Io.Writer = &filewriter.interface;
 
     try writer.print("\n\n{f}\n", .{try zbench.getSystemInfo()});
 }

--- a/examples/systeminfo.zig
+++ b/examples/systeminfo.zig
@@ -1,9 +1,8 @@
 const std = @import("std");
 const zbench = @import("zbench");
 
-pub fn main() !void {
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     var stdout: std.Io.File.Writer = std.Io.File.stdout().writerStreaming(io, &.{});
     const writer = &stdout.interface;
 

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -108,10 +108,10 @@ pub const Definition = struct {
             .parameterised => |x| x.func(@ptrCast(x.context), allocator),
         }
         const t1_ns: i96 = t0.untilNow(io, .awake).toNanoseconds();
-        assert(t1_ns > 0);
 
         return Runner.Reading{
-            .timing_ns = @intCast(t1_ns),
+            // Extremely fast benchmarks can quantize to 0ns on some systems.
+            .timing_ns = clampTimingNs(t1_ns),
             .allocation = if (tracking) |trk| Runner.AllocationReading{
                 .max = trk.maxAllocated(),
                 .count = trk.allocationCount(),
@@ -119,3 +119,13 @@ pub const Definition = struct {
         };
     }
 };
+
+fn clampTimingNs(t1_ns: i96) u64 {
+    assert(t1_ns >= 0);
+    return @intCast(@max(t1_ns, 1));
+}
+
+test "zero-duration readings are floored to one nanosecond" {
+    try std.testing.expectEqual(@as(u64, 1), clampTimingNs(0));
+    try std.testing.expectEqual(@as(u64, 42), clampTimingNs(42));
+}


### PR DESCRIPTION
https://codeberg.org/ziglang/zig/pulls/30644

- fixed also an issues when a benchmark is [too fast](https://github.com/hendriknielaender/zBench/pull/148/changes#diff-50c3a64cbc2e1c22db2c57d14955e6739c52d2ce9013133d934e55e616f159bfR113)

